### PR TITLE
Respecting the requested callback queue when invoking subscription re…

### DIFF
--- a/AWSAppSyncClient/AWSAppSyncSubscriptionWatcher.swift
+++ b/AWSAppSyncClient/AWSAppSyncSubscriptionWatcher.swift
@@ -59,7 +59,11 @@ public final class AWSAppSyncSubscriptionWatcher<Subscription: GraphQLSubscripti
         self.store = store
         self.subscription = subscription
         self.handlerQueue = handlerQueue
-        self.resultHandler = resultHandler
+        self.resultHandler = { (result, transaction, error) in
+            handlerQueue.async {
+                resultHandler(result, transaction, error)
+            }
+        }
         // start the subscriptionr request process on a background thread
         DispatchQueue.global(qos: .userInitiated).async {
             self.startSubscription()


### PR DESCRIPTION
The handlerQueue passed to the subscription watcher is not being used internally, so all subscription events callback on some internal Apollo queue.
This fixes that by always asynchronously dispatching to the handler queue.