### PR TITLE
Calling the AWSAppSyncClientConfiguration connectionStateChangeHandler

### DIFF
--- a/AWSAppSyncClient/AWSAppSyncClient.swift
+++ b/AWSAppSyncClient/AWSAppSyncClient.swift
@@ -328,6 +328,7 @@ public class AWSAppSyncClient: NetworkConnectionNotification {
         self.appSyncMQTTClient.allowCellularAccess = self.appSyncConfiguration.allowsCellularAccess
         self.presignedURLClient = appSyncConfig.presignedURLClient
         self.s3ObjectManager = appSyncConfig.s3ObjectManager
+        self.connectionStateChangeHandler = appSyncConfiguration.connectionStateChangeHandler
         
         if let apiKeyAuthProvider = appSyncConfig.apiKeyAuthProvider {
             self.httpTransport = AWSAppSyncHTTPNetworkTransport(url: self.appSyncConfiguration.url,
@@ -360,6 +361,7 @@ public class AWSAppSyncClient: NetworkConnectionNotification {
         
         self.offlineMutationExecutor = MutationExecutor(networkClient: self.httpTransport!, appSyncClient: self, snapshotProcessController: SnapshotProcessController(endpointURL:self.appSyncConfiguration.url), fileURL: self.appSyncConfiguration.databaseURL)
         networkStatusWatchers.append(self.offlineMutationExecutor!)
+        networkStatusWatchers.append(self)
         
         
         NotificationCenter.default.addObserver(self, selector: #selector(checkForReachability(note:)), name: .reachabilityChanged, object: reachability)
@@ -503,7 +505,7 @@ public class AWSAppSyncClient: NetworkConnectionNotification {
     func onNetworkAvailabilityStatusChanged(isEndpointReachable: Bool) {
         var accessState: ClientNetworkAccessState = .Offline
         if (isEndpointReachable) {
-            accessState = .Offline
+            accessState = .Online
         }
         self.connectionStateChangeHandler?.stateChanged(networkState: accessState)
     }


### PR DESCRIPTION
Calling the AWSAppSyncClientConfiguration connectionStateChangeHandler on network availability changes and using .Online when the endpoint is reachable.
