### PR TITLE
Replaced generic struct based AWSAppSyncClientError by a typed enum…

### DIFF
--- a/AWSAppSyncClient/AWSAppSyncClient.swift
+++ b/AWSAppSyncClient/AWSAppSyncClient.swift
@@ -571,7 +571,7 @@ public enum AWSAppSyncClientError: Error, LocalizedError {
             return data
         case .requestFailed(let data, _, _):
             return data
-        case .noData:
+        case .noData, .authenticationError(_):
             return nil
         }
     }
@@ -580,10 +580,10 @@ public enum AWSAppSyncClientError: Error, LocalizedError {
     public var response: HTTPURLResponse? {
         switch self {
         case .parseError(_, let response, _):
-            return response as? HTTPURLResponse
+            return response
         case .requestFailed(_, let response, _):
-            return response as? HTTPURLResponse
-        case .noData:
+            return response
+        case .noData, .authenticationError(_):
             return nil
         }
     }
@@ -600,7 +600,7 @@ public enum AWSAppSyncClientError: Error, LocalizedError {
             return "Could not parse response data."
         case .requestFailed(_, _, _):
             return "Did not receive a successful HTTP code."
-        case .noData:
+        case .noData, .authenticationError(_):
             return "No Data received in response."
         }
     }

--- a/AWSAppSyncClient/AWSAppSyncClient.swift
+++ b/AWSAppSyncClient/AWSAppSyncClient.swift
@@ -563,6 +563,47 @@ public enum AWSAppSyncClientError: Error, LocalizedError {
             return "\(message)"
         }
     }
+    
+    @available(*, deprecated, message: "use the enum pattern matching instead")
+    public var body: Data? {
+        switch self {
+        case .parseError(let data, _, _):
+            return data
+        case .requestFailed(let data, _, _):
+            return data
+        case .noData:
+            return nil
+        }
+    }
+    
+    @available(*, deprecated, message: "use the enum pattern matching instead")
+    public var response: HTTPURLResponse? {
+        switch self {
+        case .parseError(_, let response, _):
+            return response as? HTTPURLResponse
+        case .requestFailed(_, let response, _):
+            return response as? HTTPURLResponse
+        case .noData:
+            return nil
+        }
+    }
+    
+    @available(*, deprecated)
+    var isInternalError: Bool {
+        return false
+    }
+    
+    @available(*, deprecated, message: "use errorDescription instead")
+    var additionalInfo: String? {
+        switch self {
+        case .parseError(_, _, _):
+            return "Could not parse response data."
+        case .requestFailed(_, _, _):
+            return "Did not receive a successful HTTP code."
+        case .noData:
+            return "No Data received in response."
+        }
+    }
 }
 
 public struct AWSAppSyncSubscriptionError: Error, LocalizedError {

--- a/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
+++ b/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
@@ -264,13 +264,13 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
                 if let error = task.error {
                     completionHandler(.failure(error))
                 } else {
-                    completionHandler(.success())
+                    completionHandler(.success(()))
                 }
                 return nil
             }
         case .apiKey:
             mutableRequest.setValue(self.apiKeyAuthProvider!.getAPIKey(), forHTTPHeaderField: "x-api-key")
-            completionHandler(.success())
+            completionHandler(.success(()))
         case .oidcToken:
             if let provider = self.oidcAuthProvider as? AWSOIDCAuthProviderAsync {
             
@@ -280,7 +280,7 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
                     }
                     else if let token = token {
                         mutableRequest.setValue(token, forHTTPHeaderField: "authorization")
-                        completionHandler(.success())
+                        completionHandler(.success(()))
                     }
                     else {
                         fatalError("Invalid data returned in token callback")
@@ -288,7 +288,7 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
                 }
             } else if let provider = self.oidcAuthProvider {
                  mutableRequest.setValue(provider.getLatestAuthToken(), forHTTPHeaderField: "authorization")
-                 completionHandler(.success())
+                 completionHandler(.success(()))
             } else {
                 fatalError("Authentication provider not set")
             }
@@ -301,7 +301,7 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
                     }
                     else if let token = token {
                         mutableRequest.setValue(token, forHTTPHeaderField: "authorization")
-                        completionHandler(.success())
+                        completionHandler(.success(()))
                     }
                     else {
                         fatalError("Invalid data returned in token callback")
@@ -309,7 +309,7 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
                 }
             } else if let provider = self.userPoolsAuthProvider {
                 mutableRequest.setValue(provider.getLatestAuthToken(), forHTTPHeaderField: "authorization")
-                completionHandler(.success())
+                completionHandler(.success(()))
             } else {
                 fatalError("Authentication provider not set")
             }

--- a/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
+++ b/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
@@ -174,19 +174,17 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
     internal func sendGraphQLRequest(mutableRequest: NSMutableURLRequest,
                                     retryHandler: AWSAppSyncRetryHandler,
                                     networkTransportOperation: AWSAppSyncHTTPNetworkTransportOperation,
-                                    completionHandler: @escaping (JSONObject?, Error?) -> Void) {
-        updateRequestWithAuthInformation(mutableRequest: mutableRequest, completionHandler: { error in
-            guard error == nil else {
-                completionHandler(nil, error)
-                return
-            }
-            let dataTask = self.sendNetworkRequest(request: mutableRequest as URLRequest, completionHandler: {[weak self] (jsonBody, httpResponse, error) in
-                guard error == nil else {
-                    if let appsyncError = error as? AWSAppSyncClientError,
-                        let response = appsyncError.response,
-                        let body = appsyncError.body {
-                        let (shouldRetry, backoffTime) = retryHandler.shouldRetryRequest(httpResponse: response, body: body)
-                        if (shouldRetry == true && backoffTime != nil) {
+                                    completionHandler: @escaping (JSONObject?, AWSAppSyncClientError?) -> Void) {
+        updateRequestWithAuthInformation(mutableRequest: mutableRequest, completionHandler: { result in
+            switch result {
+            case .success:
+                let dataTask = self.sendNetworkRequest(request: mutableRequest as URLRequest, completionHandler: {[weak self] (result) in
+                    switch result {
+                    case .success(let jsonBody):
+                        completionHandler(jsonBody, nil)
+                    case .failure(let error):
+                        let (shouldRetry, backoffTime) = retryHandler.shouldRetryRequest(for: error)
+                        if (shouldRetry && backoffTime != nil) {
                             let _ = self?.executeAfter(milliseconds: backoffTime!, queue: DispatchQueue.global(qos: .userInitiated), block: {
                                 self?.sendGraphQLRequest(mutableRequest: mutableRequest,
                                                          retryHandler: retryHandler,
@@ -196,11 +194,12 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
                             completionHandler(nil, error)
                         }
                     }
-                    return
-                }
-                completionHandler(jsonBody, nil)
-            })
-            networkTransportOperation.dataTask = dataTask
+                })
+                networkTransportOperation.dataTask = dataTask
+            case .failure(let error):
+                completionHandler(nil, AWSAppSyncClientError.authenticationError(error))
+            }
+            
         })
     }
     
@@ -210,12 +209,12 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
     ///   - request: The URL request to be sent
     ///   - completionHandler: The completion handler which will be called once the request is completed
     /// - Returns: URLSessionDataTask cancellable object
-    internal func sendNetworkRequest(request: URLRequest, completionHandler: @escaping ((JSONObject?, HTTPURLResponse?, Error?) -> Void)) -> URLSessionDataTask {
+    internal func sendNetworkRequest(request: URLRequest, completionHandler: @escaping (Result<JSONObject, AWSAppSyncClientError>) -> Void) -> URLSessionDataTask {
         
         let dataTask = self.session.dataTask(with: request, completionHandler: { (data: Data?, response: URLResponse?, error:Error?) in
             
-            if error != nil {
-                completionHandler(nil, nil, error)
+            if let error = error {
+                completionHandler(.failure(AWSAppSyncClientError.requestFailed(data, nil, error)))
                 return
             }
             
@@ -224,24 +223,25 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
             }
             
             if (!httpResponse.isSuccessful) {
-                let err = AWSAppSyncClientError(body: data, response: httpResponse, isInternalError: false, additionalInfo: "Did not receive a successful HTTP code.")
-                completionHandler(nil, nil, err)
+                completionHandler(.failure(AWSAppSyncClientError.requestFailed(data, httpResponse, error)))
+
                 return
             }
             
             guard let data = data else {
-                let err = AWSAppSyncClientError(body: nil, response: httpResponse, isInternalError: false, additionalInfo: "No Data received in response.")
-                completionHandler(nil, nil, err)
+                completionHandler(.failure(AWSAppSyncClientError.noData(httpResponse)))
+
                 return
             }
             do {
                 guard let body =  try self.serializationFormat.deserialize(data: data) as? JSONObject else {
-                    throw AWSAppSyncClientError(body: data, response: httpResponse, isInternalError: false, additionalInfo: "Could not parse response data.")
+                    completionHandler(.failure(AWSAppSyncClientError.parseError(data, httpResponse, nil)))
+
+                    return
                 }
-                
-                completionHandler(body, httpResponse, error)
+                completionHandler(.success(body))
             } catch {
-                completionHandler(nil, nil, error)
+                completionHandler(.failure(AWSAppSyncClientError.parseError(data, httpResponse, error)))
             }
             
         })
@@ -253,7 +253,7 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
     /// Updates the sendRequest with the appropriate authentication parameters
     /// In the case of a token retrieval error, the errorCallback is invoked
     private func updateRequestWithAuthInformation(mutableRequest: NSMutableURLRequest,
-                                                completionHandler: @escaping ((Error?) -> Void)) -> Void {
+                                                  completionHandler: @escaping (Result<Void, Error>) -> Void) -> Void {
 
         switch self.authType {
             
@@ -262,25 +262,25 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
             
             signer.interceptRequest(mutableRequest).continueWith { task in
                 if let error = task.error {
-                    completionHandler(error)
+                    completionHandler(.failure(error))
                 } else {
-                    completionHandler(nil)
+                    completionHandler(.success())
                 }
                 return nil
             }
         case .apiKey:
             mutableRequest.setValue(self.apiKeyAuthProvider!.getAPIKey(), forHTTPHeaderField: "x-api-key")
-            completionHandler(nil)
+            completionHandler(.success())
         case .oidcToken:
             if let provider = self.oidcAuthProvider as? AWSOIDCAuthProviderAsync {
             
                 provider.getLatestAuthToken { (token, error) in
                     if let error = error {
-                        completionHandler(error)
+                        completionHandler(.failure(error))
                     }
                     else if let token = token {
                         mutableRequest.setValue(token, forHTTPHeaderField: "authorization")
-                        completionHandler(nil)
+                        completionHandler(.success())
                     }
                     else {
                         fatalError("Invalid data returned in token callback")
@@ -288,7 +288,7 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
                 }
             } else if let provider = self.oidcAuthProvider {
                  mutableRequest.setValue(provider.getLatestAuthToken(), forHTTPHeaderField: "authorization")
-                 completionHandler(nil)
+                 completionHandler(.success())
             } else {
                 fatalError("Authentication provider not set")
             }
@@ -297,11 +297,11 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
                 
                 provider.getLatestAuthToken { (token, error) in
                     if let error = error {
-                        completionHandler(error)
+                        completionHandler(.failure(error))
                     }
                     else if let token = token {
                         mutableRequest.setValue(token, forHTTPHeaderField: "authorization")
-                        completionHandler(nil)
+                        completionHandler(.success())
                     }
                     else {
                         fatalError("Invalid data returned in token callback")
@@ -309,7 +309,7 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
                 }
             } else if let provider = self.userPoolsAuthProvider {
                 mutableRequest.setValue(provider.getLatestAuthToken(), forHTTPHeaderField: "authorization")
-                completionHandler(nil)
+                completionHandler(.success())
             } else {
                 fatalError("Authentication provider not set")
             }
@@ -434,4 +434,10 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
             self.dataTask?.cancel()
         }
     }
+    
+    internal enum Result<V, E> {
+        case success(V)
+        case failure(E)
+    }
+
 }

--- a/AWSAppSyncTests/AuthProviderTests.swift
+++ b/AWSAppSyncTests/AuthProviderTests.swift
@@ -156,7 +156,11 @@ class AuthProviderTests: XCTestCase {
         
         client.perform(mutation: mutation, resultHandler: { (_, error) in
             XCTAssert(error != nil)
-            XCTAssert(error is AuthProviderTestError)
+            if case AWSAppSyncClientError.authenticationError(let authError) = error as! AWSAppSyncClientError {
+                XCTAssert(authError is AuthProviderTestError)
+            } else {
+                XCTAssertTrue(false, "Error of unexpected type")
+            }
             expectation2.fulfill()
         })
         


### PR DESCRIPTION
The struct based `AWSAppSyncClientError` doesn't provide enough informations about the error. Requiring the user to do string matching with `additionalInfo` to figure out what exactly went wrong. 

Description of changes:
- Replaced the struct based `AWSAppSyncClientError` by a typed enum based, providing better description for each type of error, including inner errors when applied.
- Moved common request code into a single method in `AWSAppSyncHTTPNetworkTransport`.

Considerations:
- Good to have in mind that this PR changes the public interface. Being **non backward compatible** with written code.