### PR TITLE
AWSNetworkTransport modifications to enable the ability to mock server

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		17E009DA1FCAB234005031DB /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E009B81FCAB233005031DB /* Result.swift */; };
 		17E009DB1FCAB234005031DB /* NormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E009B91FCAB234005031DB /* NormalizedCache.swift */; };
 		17E009DC1FCAB234005031DB /* ApolloClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E009BA1FCAB234005031DB /* ApolloClient.swift */; };
+		DF9468DB20E1CA4A00E40482 /* AWSNetworkTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9468DA20E1CA4A00E40482 /* AWSNetworkTransport.swift */; };
 		E4EA2880833EDE9A29FEBC15 /* Pods_AWSAppSync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 621AB86198B779E235D8B962 /* Pods_AWSAppSync.framework */; };
 /* End PBXBuildFile section */
 
@@ -142,6 +143,7 @@
 		621AB86198B779E235D8B962 /* Pods_AWSAppSync.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSAppSync.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD111EB21748A599F5796B74 /* Pods-AWSAppSync.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSync.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSync/Pods-AWSAppSync.debug.xcconfig"; sourceTree = "<group>"; };
 		C830ED8003E746C4C6799F8E /* Pods-AWSAppSync.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSync.release.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSync/Pods-AWSAppSync.release.xcconfig"; sourceTree = "<group>"; };
+		DF9468DA20E1CA4A00E40482 /* AWSNetworkTransport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSNetworkTransport.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -232,6 +234,7 @@
 				17DECF611F59F5FF004B0512 /* AWSAppSync.h */,
 				17DECF621F59F5FF004B0512 /* Info.plist */,
 				17A66BA31F59FF69008DDA11 /* AWSAppSyncClient.swift */,
+				DF9468DA20E1CA4A00E40482 /* AWSNetworkTransport.swift */,
 				17915B041F5F106600C4B73C /* AWSAppSyncHTTPNetworkTransport.swift */,
 				17A2673C1F66465B009E50B7 /* AWSSQLLiteNormalizedCache.swift */,
 				17D2C2061F6F44A3006C6818 /* AWSOfflineMutationStore.swift */,
@@ -422,6 +425,7 @@
 				1729A0BF1F9DAB2400F88594 /* AWSSRWebSocket.m in Sources */,
 				17E009BC1FCAB234005031DB /* AWSGraphQLSubscriptionResponse.swift in Sources */,
 				1729A0B11F9DAB2400F88594 /* MQTTClient.m in Sources */,
+				DF9468DB20E1CA4A00E40482 /* AWSNetworkTransport.swift in Sources */,
 				17E009C91FCAB234005031DB /* Record.swift in Sources */,
 				17E009D41FCAB234005031DB /* GraphQLResultNormalizer.swift in Sources */,
 				17E009C01FCAB234005031DB /* InMemoryNormalizedCache.swift in Sources */,

--- a/AWSAppSyncClient/AWSAppSyncClient.swift
+++ b/AWSAppSyncClient/AWSAppSyncClient.swift
@@ -87,12 +87,7 @@ public class AWSAppSyncClientConfiguration {
     fileprivate var region: AWSRegionType
     fileprivate var store: ApolloStore
     fileprivate var networkTransport: AWSNetworkTransport
-//    fileprivate var urlSessionConfiguration: URLSessionConfiguration
-
-//    fileprivate var credentialsProvider: AWSCredentialsProvider? = nil
     fileprivate var databaseURL: URL?
-//    fileprivate var apiKeyAuthProvider: AWSAPIKeyAuthProvider? = nil
-//    fileprivate var userPoolsAuthProvider: AWSCognitoUserPoolsAuthProvider? = nil
     fileprivate var oidcAuthProvider: AWSOIDCAuthProvider? = nil
     fileprivate var snapshotController: SnapshotProcessController? = nil
     fileprivate var s3ObjectManager: AWSS3ObjectManager? = nil

--- a/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
+++ b/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
@@ -12,7 +12,7 @@ enum AuthType {
     case oidcToken
 }
 
-public class AWSAppSyncHTTPNetworkTransport: NetworkTransport {
+public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
     let url: URL
     let session: URLSession
     var region: AWSRegionType? = nil

--- a/AWSAppSyncClient/AWSAppSyncSubscriptionWatcher.swift
+++ b/AWSAppSyncClient/AWSAppSyncSubscriptionWatcher.swift
@@ -45,7 +45,7 @@ class SubscriptionsOrderHelper {
 public final class AWSAppSyncSubscriptionWatcher<Subscription: GraphQLSubscription>: MQTTSubscritionWatcher, Cancellable {
     
     weak var client: AppSyncMQTTClient?
-    weak var httpClient: AWSAppSyncHTTPNetworkTransport?
+    weak var httpClient: AWSNetworkTransport?
     let subscription: Subscription?
     let handlerQueue: DispatchQueue
     let resultHandler: SubscriptionResultHandler<Subscription>
@@ -53,7 +53,7 @@ public final class AWSAppSyncSubscriptionWatcher<Subscription: GraphQLSubscripti
     let store: ApolloStore
     public let uniqueIdentifier = SubscriptionsOrderHelper.sharedInstance.getLatestCount()
     
-    init(client: AppSyncMQTTClient, httpClient: AWSAppSyncHTTPNetworkTransport, store: ApolloStore, subscription: Subscription, handlerQueue: DispatchQueue, resultHandler: @escaping SubscriptionResultHandler<Subscription>) {
+    init(client: AppSyncMQTTClient, httpClient: AWSNetworkTransport, store: ApolloStore, subscription: Subscription, handlerQueue: DispatchQueue, resultHandler: @escaping SubscriptionResultHandler<Subscription>) {
         self.client = client
         self.httpClient = httpClient
         self.store = store

--- a/AWSAppSyncClient/AWSNetworkTransport.swift
+++ b/AWSAppSyncClient/AWSNetworkTransport.swift
@@ -1,0 +1,11 @@
+//
+//  AWSNetworkTransport.swift
+//  AWSAppSyncClient
+//
+
+import Foundation
+
+public protocol AWSNetworkTransport: AnyObject, NetworkTransport {
+    func send(data: Data, completionHandler: ((JSONObject?, Error?) -> Void)?)
+    func sendSubscriptionRequest<Operation: GraphQLOperation>(operation: Operation, completionHandler: @escaping (JSONObject?, Error?) -> Void) throws -> Cancellable
+}

--- a/AWSAppSyncClient/AWSOfflineMutationStore.swift
+++ b/AWSAppSyncClient/AWSOfflineMutationStore.swift
@@ -138,7 +138,7 @@ class MutationExecutor: NetworkConnectionNotification {
     
     let isExecutingDispatchGroup = DispatchGroup()
     var currentMutation: AWSAppSyncMutationRecord?
-    var networkClient: AWSAppSyncHTTPNetworkTransport
+    var networkClient: AWSNetworkTransport
     var appSyncClient: AWSAppSyncClient
     var handlerQueue = DispatchQueue.main
     var store: ApolloStore?
@@ -147,7 +147,7 @@ class MutationExecutor: NetworkConnectionNotification {
     private var persistentCache: AWSMutationCache?
     var snapshotProcessController: SnapshotProcessController
     
-    init(networkClient: AWSAppSyncHTTPNetworkTransport,
+    init(networkClient: AWSNetworkTransport,
          appSyncClient: AWSAppSyncClient,
          snapshotProcessController: SnapshotProcessController,
          fileURL: URL? = nil) {


### PR DESCRIPTION
Issue #38 

The purpose of this PR is to expose the NetworkTransport class that is used by the App Sync SDK so it is possible to create a Mock Network Transport object to control what responses from the server look like in our Functional UI tests.

*Description of changes:*

* Creating a protocol outlining the requirements for a NetworkTransport class

* Modifying internal dependecies on the concrete AWSAppSyncHTTPNetworkTransport class, so they are only depedent on the protocol

* Exposing a new configuration initializer for app sync where the app can create their own network transport class. This includes a small refactor to the configuration class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.