### PR TITLE
Remove version specifications from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The AWS AppSync SDK for iOS enables you to access your AWS AppSync backend and p
 1. Add the following line to your Podfile:
 
 ```
-  pod 'AWSAppSync', '~> 2.6.7'
+  pod 'AWSAppSync'
 ```
 
 Example:
@@ -31,7 +31,7 @@ target 'EventsApp' do
   use_frameworks!
 
   # Pods for EventsApp
-  pod 'AWSAppSync', '~> 2.6.7'
+  pod 'AWSAppSync'
 end
 ```
 


### PR DESCRIPTION
Probably better to just leave off the version specifications and let users decide on their own. Also, it would require updating the `README.md` on every release which didn't happen for 10 releases haha.