### PR TITLE
AppSyncClient clean up

### DIFF
--- a/AWSAppSyncClient/AWSAppSyncClient.swift
+++ b/AWSAppSyncClient/AWSAppSyncClient.swift
@@ -299,7 +299,7 @@ public class AWSAppSyncClient: NetworkConnectionNotification {
     
     public let apolloClient: ApolloClient?
     public var offlineMutationDelegate: AWSAppSyncOfflineMutationDelegate?
-    public let store: ApolloStore?
+    public let store: ApolloStore
     public let presignedURLClient: AWSS3ObjectPresignedURLGenerator?
     public let s3ObjectManager: AWSS3ObjectManager?
     
@@ -417,7 +417,7 @@ public class AWSAppSyncClient: NetworkConnectionNotification {
         
         return AWSAppSyncSubscriptionWatcher(client: self.appSyncMQTTClient,
                                               httpClient: self.httpTransport,
-                                              store: self.store!,
+                                              store: self.store,
                                               subscription: subscription,
                                               handlerQueue: queue,
                                               resultHandler: resultHandler)
@@ -441,7 +441,7 @@ public class AWSAppSyncClient: NetworkConnectionNotification {
                                                                       resultHandler: OperationResultHandler<Mutation>? = nil) -> PerformMutationOperation<Mutation>? {
         if let optimisticUpdate = optimisticUpdate {
             do {
-                let _ = try self.store?.withinReadWriteTransaction { transaction in
+                let _ = try self.store.withinReadWriteTransaction { transaction in
                     optimisticUpdate(transaction)
                     }.await()
             } catch {

--- a/AWSAppSyncClient/AWSAppSyncClientConflictResolutionExtensions.swift
+++ b/AWSAppSyncClient/AWSAppSyncClientConflictResolutionExtensions.swift
@@ -40,7 +40,7 @@ extension AWSAppSyncClient {
             }
             
             firstly {
-                try response.parseResult(cacheKeyForObject: self.store!.cacheKeyForObject)
+                try response.parseResult(cacheKeyForObject: self.store.cacheKeyForObject)
                 }.andThen { (result, records) in
                     if let resultError = result.errors,
                         let conflictResolutionBlock = conflictResolutionBlock,
@@ -61,7 +61,7 @@ extension AWSAppSyncClient {
                     } else {
                         notifyResultHandler(result: result, error: nil)
                         if let records = records {
-                            self.store?.publish(records: records, context: context).catch { error in
+                            self.store.publish(records: records, context: context).catch { error in
                                 preconditionFailure(String(describing: error))
                             }
                         }

--- a/AWSAppSyncClient/AWSAppSyncClientConflictResolutionExtensions.swift
+++ b/AWSAppSyncClient/AWSAppSyncClientConflictResolutionExtensions.swift
@@ -33,7 +33,7 @@ extension AWSAppSyncClient {
             }
         }
         
-        return self.httpTransport!.send(operation: operation) { (response, error) in
+        return self.httpTransport.send(operation: operation) { (response, error) in
             guard let response = response else {
                 notifyResultHandler(result: nil, error: error)
                 return

--- a/AWSAppSyncClient/AWSAppSyncClientS3ObjectsExtensions.swift
+++ b/AWSAppSyncClient/AWSAppSyncClientS3ObjectsExtensions.swift
@@ -24,7 +24,7 @@ extension AWSAppSyncClient {
 
         self.s3ObjectManager!.upload(s3Object: s3Object) { (isSuccessful, error) in
             if (isSuccessful) {
-                self.httpTransport?.send(data: data) { (result, error) in
+                self.httpTransport.send(data: data) { (result, error) in
                 }
             } else {
                 if let resultHandler = resultHandler {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

- Removes duplicate code from `AppSyncClient` and `AppSyncClientConfiguration`
- Eradicates the need for force unwrapping in most of the `AppSyncClient` and `AppSyncClientConfiguration`
- Refactors reachability into `SnapshotProcessController` and removes some previous dead code with regards to reachability checks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
