### PR TITLE
Fixing customer reported documentation issue

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,8 +76,6 @@ The AppSync iOS client generates a strongly typed API for your backend based on 
 To interact with AWS AppSync, your client needs to define GraphQL
 queries, mutations and subscriptions which are converted to strongly typed `Swift` objects.
 
-Save the  We will use this folder for storing our `GraphQL` related files.
-
 This can be done by creating a `posts.graphql` file in a folder with name like `GraphQLOperations.` Put the following operations in `posts.graphql`:
 
 ```javascript


### PR DESCRIPTION
This line seems to be here by mistake.

*Issue #, if available:*
N/A

*Description of changes:*
Remove "Save the We will use this folder for storing our GraphQL related files."

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
