### PR TITLE
Allow Auth credentials to be fetched via callback

### DIFF
--- a/AWSAppSyncClient/AWSAppSyncAuthProvider.swift
+++ b/AWSAppSyncClient/AWSAppSyncAuthProvider.swift
@@ -8,7 +8,7 @@ import Foundation
 // For using OIDC based authorization, this protocol needs to be implemented and passed to configuration object.
 public protocol AWSOIDCAuthProvider {
     /// The method should fetch the token and return it to the client for using in header request.
-    func getLatestAuthToken() -> String
+    func getLatestAuthToken(_ callback: @escaping (String) -> Void)
 }
 
 // For using Cognito User Pools based authorization, this protocol needs to be implemented and passed to configuration object.


### PR DESCRIPTION
For OIDC or Cognito authentication, auth tokens often expire and need to be re-generated. Using a callback follows the model also used by aws-mobile-appsync-sdk-js

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
