### PR TITLE
Added checks to ensure that the SDK doesn't crash if the received mes…

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		17E009DB1FCAB234005031DB /* NormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E009B91FCAB234005031DB /* NormalizedCache.swift */; };
 		17E009DC1FCAB234005031DB /* ApolloClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E009BA1FCAB234005031DB /* ApolloClient.swift */; };
 		7C8D9BD0CFD94CE97870947D /* Pods_AWSAppSyncTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB93C78C2EEB30A1C3C24E2E /* Pods_AWSAppSyncTests.framework */; };
+		9AA1ADA9213096A20081E6A9 /* AWSAppSyncLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA1ADA8213096A20081E6A9 /* AWSAppSyncLog.swift */; };
 		DF9468DB20E1CA4A00E40482 /* AWSNetworkTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9468DA20E1CA4A00E40482 /* AWSNetworkTransport.swift */; };
 		E4EA2880833EDE9A29FEBC15 /* Pods_AWSAppSync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 621AB86198B779E235D8B962 /* Pods_AWSAppSync.framework */; };
 /* End PBXBuildFile section */
@@ -169,6 +170,7 @@
 		621AB86198B779E235D8B962 /* Pods_AWSAppSync.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSAppSync.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A5E9B8BFB35E672A4BA10CD /* Pods-AWSAppSyncTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSyncTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSyncTests/Pods-AWSAppSyncTests.release.xcconfig"; sourceTree = "<group>"; };
 		9A210F34AE9783A62B36F8F2 /* Pods-AWSAppSyncTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSyncTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSyncTests/Pods-AWSAppSyncTests.debug.xcconfig"; sourceTree = "<group>"; };
+		9AA1ADA8213096A20081E6A9 /* AWSAppSyncLog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAppSyncLog.swift; sourceTree = "<group>"; };
 		AD111EB21748A599F5796B74 /* Pods-AWSAppSync.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSync.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSync/Pods-AWSAppSync.debug.xcconfig"; sourceTree = "<group>"; };
 		C830ED8003E746C4C6799F8E /* Pods-AWSAppSync.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSync.release.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSync/Pods-AWSAppSync.release.xcconfig"; sourceTree = "<group>"; };
 		CB93C78C2EEB30A1C3C24E2E /* Pods_AWSAppSyncTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSAppSyncTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -284,6 +286,7 @@
 		17DECF601F59F5FF004B0512 /* AWSAppSyncClient */ = {
 			isa = PBXGroup;
 			children = (
+				9AA1ADA8213096A20081E6A9 /* AWSAppSyncLog.swift */,
 				17E009981FCAB214005031DB /* Apollo */,
 				1729A07F1F9DAB2300F88594 /* MQTTSDK */,
 				17DECF611F59F5FF004B0512 /* AWSAppSync.h */,
@@ -591,6 +594,7 @@
 				17E009BE1FCAB234005031DB /* JSON.swift in Sources */,
 				174F808E2107E74F00775D0D /* AWSMQttTxFlow.m in Sources */,
 				17A66BA41F59FF69008DDA11 /* AWSAppSyncClient.swift in Sources */,
+				9AA1ADA9213096A20081E6A9 /* AWSAppSyncLog.swift in Sources */,
 				17E009C61FCAB234005031DB /* GraphQLSelectionSet.swift in Sources */,
 				17E009C81FCAB234005031DB /* Locking.swift in Sources */,
 				174F80922107E74F00775D0D /* AWSMQTTDecoder.m in Sources */,

--- a/AWSAppSyncClient/AWSAppSyncClient.swift
+++ b/AWSAppSyncClient/AWSAppSyncClient.swift
@@ -110,6 +110,7 @@ public class AWSAppSyncClientConfiguration {
     ///   - connectionStateChangeHandler: The delegate object to be notified when client network state changes.
     ///   - s3ObjectManager: The client used for uploading / downloading `S3Objects`.
     ///   - presignedURLClient: The `AWSAppSyncClientConfiguration` object.
+    ///   - loggingClient: The logging client for application logging.
     public convenience init(url: URL,
                             serviceRegion: AWSRegionType,
                             credentialsProvider: AWSCredentialsProvider,
@@ -117,7 +118,8 @@ public class AWSAppSyncClientConfiguration {
                             databaseURL: URL? = nil,
                             connectionStateChangeHandler: ConnectionStateChangeHandler? = nil,
                             s3ObjectManager: AWSS3ObjectManager? = nil,
-                            presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil) throws {
+                            presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil,
+                            loggingClient: AWSAppSyncLogClient? = nil) throws {
         try self.init(url: url,
                       serviceRegion: serviceRegion,
                       authType: AuthType.awsIAM,
@@ -129,7 +131,8 @@ public class AWSAppSyncClientConfiguration {
                       databaseURL: databaseURL,
                       connectionStateChangeHandler: connectionStateChangeHandler,
                       s3ObjectManager: s3ObjectManager,
-                      presignedURLClient: presignedURLClient)
+                      presignedURLClient: presignedURLClient,
+                      loggingClient: loggingClient)
     }
     
     /// Creates a configuration object for the `AWSAppSyncClient`.
@@ -145,6 +148,7 @@ public class AWSAppSyncClientConfiguration {
     ///   - connectionStateChangeHandler: The delegate object to be notified when client network state changes.
     ///   - s3ObjectManager: The client used for uploading / downloading `S3Objects`.
     ///   - presignedURLClient: The `AWSAppSyncClientConfiguration` object.
+    ///   - loggingClient: The logging client for application logging.
     public convenience init(appSyncClientInfo: AWSAppSyncClientInfo,
                             apiKeyAuthProvider: AWSAPIKeyAuthProvider? = nil,
                             credentialsProvider: AWSCredentialsProvider? = nil,
@@ -154,7 +158,8 @@ public class AWSAppSyncClientConfiguration {
                             databaseURL: URL? = nil,
                             connectionStateChangeHandler: ConnectionStateChangeHandler? = nil,
                             s3ObjectManager: AWSS3ObjectManager? = nil,
-                            presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil) throws {
+                            presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil,
+                            loggingClient: AWSAppSyncLogClient? = nil) throws {
         
         // Create a map of {authType -> authTypeObject}
         var authTypeObjectMap: [AuthType : Any?] = [AuthType : Any?]()
@@ -235,7 +240,8 @@ public class AWSAppSyncClientConfiguration {
                       databaseURL: databaseURL,
                       connectionStateChangeHandler: connectionStateChangeHandler,
                       s3ObjectManager: s3ObjectManager,
-                      presignedURLClient: presignedURLClient)
+                      presignedURLClient: presignedURLClient,
+                      loggingClient: loggingClient)
     }
     
     /// Creates a configuration object for the `AWSAppSyncClient`.
@@ -249,6 +255,7 @@ public class AWSAppSyncClientConfiguration {
     ///   - connectionStateChangeHandler: The delegate object to be notified when client network state changes.
     ///   - s3ObjectManager: The client used for uploading / downloading `S3Objects`.
     ///   - presignedURLClient: The `AWSAppSyncClientConfiguration` object.
+    ///   - loggingClient: The logging client for application logging.
     public convenience init(url: URL,
                             serviceRegion: AWSRegionType,
                             apiKeyAuthProvider: AWSAPIKeyAuthProvider,
@@ -256,7 +263,8 @@ public class AWSAppSyncClientConfiguration {
                             databaseURL: URL? = nil,
                             connectionStateChangeHandler: ConnectionStateChangeHandler? = nil,
                             s3ObjectManager: AWSS3ObjectManager? = nil,
-                            presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil) throws {
+                            presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil,
+                            loggingClient: AWSAppSyncLogClient? = nil ) throws {
         try self.init(url: url,
                       serviceRegion: serviceRegion,
                       authType: AuthType.apiKey,
@@ -268,7 +276,8 @@ public class AWSAppSyncClientConfiguration {
                       databaseURL: databaseURL,
                       connectionStateChangeHandler: connectionStateChangeHandler,
                       s3ObjectManager: s3ObjectManager,
-                      presignedURLClient: presignedURLClient)
+                      presignedURLClient: presignedURLClient,
+                      loggingClient: loggingClient)
     }
     
     /// Creates a configuration object for the `AWSAppSyncClient`.
@@ -282,6 +291,7 @@ public class AWSAppSyncClientConfiguration {
     ///   - connectionStateChangeHandler: The delegate object to be notified when client network state changes.
     ///   - s3ObjectManager: The client used for uploading / downloading `S3Objects`.
     ///   - presignedURLClient: The `AWSAppSyncClientConfiguration` object.
+    ///   - loggingClient: The logging client for application logging.
     public convenience init(url: URL,
                             serviceRegion: AWSRegionType,
                             userPoolsAuthProvider: AWSCognitoUserPoolsAuthProvider,
@@ -289,7 +299,8 @@ public class AWSAppSyncClientConfiguration {
                             databaseURL: URL? = nil,
                             connectionStateChangeHandler: ConnectionStateChangeHandler? = nil,
                             s3ObjectManager: AWSS3ObjectManager? = nil,
-                            presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil) throws {
+                            presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil,
+                            loggingClient: AWSAppSyncLogClient? = nil ) throws {
         try self.init(url: url,
                       serviceRegion: serviceRegion,
                       authType: AuthType.amazonCognitoUserPools,
@@ -301,7 +312,8 @@ public class AWSAppSyncClientConfiguration {
                       databaseURL: databaseURL,
                       connectionStateChangeHandler: connectionStateChangeHandler,
                       s3ObjectManager: s3ObjectManager,
-                      presignedURLClient: presignedURLClient)
+                      presignedURLClient: presignedURLClient,
+                      loggingClient: loggingClient)
     }
     
     /// Creates a configuration object for the `AWSAppSyncClient`.
@@ -315,6 +327,7 @@ public class AWSAppSyncClientConfiguration {
     ///   - connectionStateChangeHandler: The delegate object to be notified when client network state changes.
     ///   - s3ObjectManager: The client used for uploading / downloading `S3Objects`.
     ///   - presignedURLClient: The `AWSAppSyncClientConfiguration` object.
+    ///   - loggingClient: The logging client for application logging.
     public convenience init(url: URL,
                             serviceRegion: AWSRegionType,
                             oidcAuthProvider: AWSOIDCAuthProvider,
@@ -322,7 +335,8 @@ public class AWSAppSyncClientConfiguration {
                             databaseURL: URL? = nil,
                             connectionStateChangeHandler: ConnectionStateChangeHandler? = nil,
                             s3ObjectManager: AWSS3ObjectManager? = nil,
-                            presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil) throws {
+                            presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil,
+                            loggingClient: AWSAppSyncLogClient? = nil ) throws {
         try self.init(url: url,
                       serviceRegion: serviceRegion,
                       authType: AuthType.oidcToken,
@@ -334,7 +348,8 @@ public class AWSAppSyncClientConfiguration {
                       databaseURL: databaseURL,
                       connectionStateChangeHandler: connectionStateChangeHandler,
                       s3ObjectManager: s3ObjectManager,
-                      presignedURLClient: presignedURLClient)
+                      presignedURLClient: presignedURLClient,
+                      loggingClient: loggingClient)
     }
     
     /// Creates a configuration object for the `AWSAppSyncClient`.
@@ -347,13 +362,15 @@ public class AWSAppSyncClientConfiguration {
     ///   - connectionStateChangeHandler: The delegate object to be notified when client network state changes.
     ///   - s3ObjectManager: The client used for uploading / downloading `S3Objects`.
     ///   - presignedURLClient: The `AWSAppSyncClientConfiguration` object.
+    ///   - loggingClient: The logging client for application logging.
     public init(url: URL,
                 serviceRegion: AWSRegionType,
                 networkTransport: AWSNetworkTransport,
                 databaseURL: URL? = nil,
                 connectionStateChangeHandler: ConnectionStateChangeHandler? = nil,
                 s3ObjectManager: AWSS3ObjectManager? = nil,
-                presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil) throws {
+                presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil,
+                loggingClient: AWSAppSyncLogClient? = nil ) throws {
         self.url = url
         self.region = serviceRegion
         self.databaseURL = databaseURL
@@ -369,6 +386,12 @@ public class AWSAppSyncClientConfiguration {
         self.s3ObjectManager = s3ObjectManager
         self.presignedURLClient = presignedURLClient
         self.connectionStateChangeHandler = connectionStateChangeHandler
+        
+        //Create logging client if not passed in.
+        //This needs to be refactored to use the private init method.
+        if let loggingClient = loggingClient {
+            AWSAppSyncLogClient.sharedLoggingClient = loggingClient
+        }
     }
     
     /// Creates a configuration object for the `AWSAppSyncClient`.
@@ -380,12 +403,14 @@ public class AWSAppSyncClientConfiguration {
     ///   - connectionStateChangeHandler: The delegate object to be notified when client network state changes.
     ///   - s3ObjectManager: The client used for uploading / downloading `S3Objects`.
     ///   - presignedURLClient: The `AWSAppSyncClientConfiguration` object.
+    ///   - loggingClient: The logging client for application logging.
     public init(appSyncClientInfo: AWSAppSyncClientInfo,
                 networkTransport: AWSNetworkTransport,
                 databaseURL: URL? = nil,
                 connectionStateChangeHandler: ConnectionStateChangeHandler? = nil,
                 s3ObjectManager: AWSS3ObjectManager? = nil,
-                presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil) throws {
+                presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil,
+                loggingClient: AWSAppSyncLogClient? = nil) throws {
         self.url = URL(string: appSyncClientInfo.apiUrl)!
         self.region = appSyncClientInfo.region.aws_regionTypeValue()
         self.databaseURL = databaseURL
@@ -401,6 +426,13 @@ public class AWSAppSyncClientConfiguration {
         self.s3ObjectManager = s3ObjectManager
         self.presignedURLClient = presignedURLClient
         self.connectionStateChangeHandler = connectionStateChangeHandler
+        
+        //Create logging client if not passed in.
+        //This needs to be refactored to use the private init method.
+        if let loggingClient = loggingClient {
+            AWSAppSyncLogClient.sharedLoggingClient = loggingClient
+        }
+     
     }
     
     /// Creates a configuration object for the `AWSAppSyncClient`.
@@ -429,7 +461,8 @@ public class AWSAppSyncClientConfiguration {
                  databaseURL: URL? = nil,
                  connectionStateChangeHandler: ConnectionStateChangeHandler? = nil,
                  s3ObjectManager: AWSS3ObjectManager? = nil,
-                 presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil) throws {
+                 presignedURLClient: AWSS3ObjectPresignedURLGenerator? = nil,
+                 loggingClient: AWSAppSyncLogClient? = nil ) throws {
         self.url = url
         self.region = serviceRegion
         self.authType = authType
@@ -469,6 +502,10 @@ public class AWSAppSyncClientConfiguration {
         self.snapshotController = SnapshotProcessController(endpointURL: url)
         self.s3ObjectManager = s3ObjectManager
         self.presignedURLClient = presignedURLClient
+        
+        if let loggingClient = loggingClient {
+            AWSAppSyncLogClient.sharedLoggingClient = loggingClient
+        }
     }
 }
 

--- a/AWSAppSyncClient/AWSAppSyncLog.swift
+++ b/AWSAppSyncClient/AWSAppSyncLog.swift
@@ -1,0 +1,163 @@
+//
+// Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+import Foundation
+
+/// Protocol to be implemented by Log Providers.
+public protocol AWSLogProvider {
+    
+    /// Verbose Logging
+    func verbose(_ message: @autoclosure () -> Any, _ file: String, _ function: String, _ line: Int)
+    
+    /// Debug Logging
+    func debug(_ message: @autoclosure () -> Any, _ file: String, _ function: String, _ line: Int)
+    
+    /// Info Logging
+    func info(_ message: @autoclosure () -> Any, _ file: String, _ function: String, _ line: Int)
+    
+    /// Warning Logging
+    func warning(_ message: @autoclosure () -> Any, _ file: String, _ function: String, _ line: Int)
+    
+    /// Error Logging
+    func error(_ message: @autoclosure () -> Any, _ file: String, _ function: String, _ line: Int)
+}
+
+/// The default logging provider for AWS AppSync SDK
+public class AWSAppSyncDefaultLogProvider: AWSLogProvider {
+    
+    var logLevel: AWSDefaultLogProviderLogLevel
+    var dispatchQueue: DispatchQueue = DispatchQueue(label: "AWSAppSyncDefaultLogProvider" + NSUUID().uuidString, qos: DispatchQoS.default)
+    var messagesOutput: [String] = []
+    var enableMessageOutputList = false
+    
+    /// Initializer for `AWSDefaultLogProvider`. Provider a `logLevel` as required.
+    public init(logLevel: AWSDefaultLogProviderLogLevel) {
+        self.logLevel = logLevel
+    }
+    
+    // Log levels for `AWSDefaultLogProvider`
+    public enum AWSDefaultLogProviderLogLevel: Int {
+        case verbose = 50
+        case debug = 40
+        case info = 30
+        case warning = 20
+        case error = 10
+        case none = 0
+    }
+    
+    /// Set the log level to desired level
+    public func setLogLevel(logLevel: AWSDefaultLogProviderLogLevel) {
+        self.logLevel = logLevel
+    }
+    
+   
+    /// Verbose Logging
+    public func verbose(_ message: @autoclosure () -> Any, _ file: String, _ function: String, _ line: Int) {
+        guard logLevel.rawValue >= AWSDefaultLogProviderLogLevel.verbose.rawValue else {
+            return
+        }
+        logMessage("⚡️VERBOSE", message, file, function, line)
+    }
+    
+    /// Debug Logging
+    public func debug(_ message: @autoclosure () -> Any, _ file: String, _ function: String, _ line: Int) {
+        guard logLevel.rawValue >= AWSDefaultLogProviderLogLevel.debug.rawValue else {
+            return
+        }
+        logMessage("✏️DEBUG", message, file, function, line)
+    }
+    
+    /// Info Logging
+    public func info(_ message: @autoclosure () -> Any, _ file: String, _ function: String, _ line: Int) {
+        guard logLevel.rawValue >= AWSDefaultLogProviderLogLevel.info.rawValue else {
+            return
+        }
+        logMessage("ℹ️INFO", message, file, function, line)
+    }
+    
+    /// Warning Logging
+    public func warning(_ message: @autoclosure () -> Any, _ file: String, _ function: String, _ line: Int) {
+        guard logLevel.rawValue >= AWSDefaultLogProviderLogLevel.warning.rawValue else {
+            return
+        }
+        logMessage("⚠️WARNING", message, file, function, line)
+    }
+    
+    /// Error Logging
+    public func error(_ message: @autoclosure () -> Any, _ file: String, _ function: String, _ line: Int) {
+        guard logLevel.rawValue >= AWSDefaultLogProviderLogLevel.error.rawValue else {
+            return
+        }
+        logMessage("❗️ERROR", message, file, function, line)
+    }
+    
+    func logMessage(_ logType: String, _ message: @autoclosure () -> Any, _ file: String, _ function: String, _ line: Int) {
+        guard let msg = message() as? String else {
+            return
+        }
+        dispatchQueue.async {
+            print("\(Date()) \(logType): \(file.components(separatedBy: "/").last!) | \(function) | \(line) | \(msg)")
+        }
+        // for debugging and testing
+        if (enableMessageOutputList) {
+            messagesOutput.append(msg)
+        }
+    }
+}
+
+/// The logging client for AWS AppSync SDK
+public class AWSAppSyncLogClient {
+    
+    static var sharedLoggingClient = AWSAppSyncLogClient()
+  
+    static public func setSharedLoggingClient(loggingClient:AWSAppSyncLogClient ) {
+        AWSAppSyncLogClient.sharedLoggingClient = loggingClient
+    }
+    
+    var logProvider: AWSLogProvider?
+    
+    public init() {
+        logProvider = AWSAppSyncDefaultLogProvider(logLevel: .error)
+    }
+    
+    public func setLoggingProvider(provider: AWSLogProvider) {
+        logProvider = provider
+    }
+    
+    /// Verbose Logging
+    public func verbose(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
+        logProvider?.verbose(message, file, function, line)
+    }
+    
+    /// Debug Logging
+    public func debug(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
+        logProvider?.debug(message, file, function, line)
+    }
+    
+    /// Info Logging
+    public func info(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
+        logProvider?.info(message, file, function, line)
+    }
+    
+    /// Warning Logging
+    public func warning(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
+        logProvider?.warning(message, file, function, line)
+    }
+    
+    /// Error Logging
+    public func error(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
+        logProvider?.error(message, file, function, line)
+    }
+}

--- a/AWSAppSyncTests/AWSAppSyncTests.swift
+++ b/AWSAppSyncTests/AWSAppSyncTests.swift
@@ -1,6 +1,16 @@
 //
-//  AWSAppSyncTests.swift
-//  AWSAppSyncTests
+// Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
 //
 
 import XCTest
@@ -32,11 +42,15 @@ class AWSAppSyncTests: XCTestCase {
         let databaseURL = URL(fileURLWithPath:NSTemporaryDirectory()).appendingPathComponent(database_name)
         
         do {
+            let loggingClient:AWSAppSyncLogClient = AWSAppSyncLogClient()
+            loggingClient.setLoggingProvider(provider: AWSAppSyncDefaultLogProvider(logLevel: .verbose))
+            
             // Initialize the AWS AppSync configuration
             let appSyncConfig = try AWSAppSyncClientConfiguration(url: AppSyncEndpointURL,
                                                                   serviceRegion: AppSyncRegion,
                                                                   credentialsProvider: credentialsProvider,
-                                                                  databaseURL:databaseURL)
+                                                                  databaseURL:databaseURL,
+                                                                  loggingClient: loggingClient)
             // Initialize the AWS AppSync client
             appSyncClient = try AWSAppSyncClient(appSyncConfig: appSyncConfig)
             // Set id as the cache key for objects


### PR DESCRIPTION
Added checks to ensure that the SDK doesn't crash if the received message is not convertible to String or JSONObject.

Added a logger component to log the error message.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
