### PR TITLE
Allow Auth credentials to be fetched via callback, backwards compatible

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		17E009DA1FCAB234005031DB /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E009B81FCAB233005031DB /* Result.swift */; };
 		17E009DB1FCAB234005031DB /* NormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E009B91FCAB234005031DB /* NormalizedCache.swift */; };
 		17E009DC1FCAB234005031DB /* ApolloClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E009BA1FCAB234005031DB /* ApolloClient.swift */; };
+		741880B0213878B400523CA8 /* AuthProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741880AF213878B400523CA8 /* AuthProviderTests.swift */; };
 		7C8D9BD0CFD94CE97870947D /* Pods_AWSAppSyncTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB93C78C2EEB30A1C3C24E2E /* Pods_AWSAppSyncTests.framework */; };
 		DF9468DB20E1CA4A00E40482 /* AWSNetworkTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9468DA20E1CA4A00E40482 /* AWSNetworkTransport.swift */; };
 		E4EA2880833EDE9A29FEBC15 /* Pods_AWSAppSync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 621AB86198B779E235D8B962 /* Pods_AWSAppSync.framework */; };
@@ -174,6 +175,7 @@
 		17E009BA1FCAB234005031DB /* ApolloClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ApolloClient.swift; path = Apollo/Sources/Apollo/ApolloClient.swift; sourceTree = "<group>"; };
 		621AB86198B779E235D8B962 /* Pods_AWSAppSync.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSAppSync.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A5E9B8BFB35E672A4BA10CD /* Pods-AWSAppSyncTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSyncTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSyncTests/Pods-AWSAppSyncTests.release.xcconfig"; sourceTree = "<group>"; };
+		741880AF213878B400523CA8 /* AuthProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthProviderTests.swift; sourceTree = "<group>"; };
 		9A210F34AE9783A62B36F8F2 /* Pods-AWSAppSyncTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSyncTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSyncTests/Pods-AWSAppSyncTests.debug.xcconfig"; sourceTree = "<group>"; };
 		AD111EB21748A599F5796B74 /* Pods-AWSAppSync.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSync.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSync/Pods-AWSAppSync.debug.xcconfig"; sourceTree = "<group>"; };
 		C830ED8003E746C4C6799F8E /* Pods-AWSAppSync.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSync.release.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSync/Pods-AWSAppSync.release.xcconfig"; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 		174F80AD2109229C00775D0D /* AWSAppSyncTests */ = {
 			isa = PBXGroup;
 			children = (
+				741880AF213878B400523CA8 /* AuthProviderTests.swift */,
 				174F80AE2109229C00775D0D /* AWSAppSyncTests.swift */,
 				174F80B02109229C00775D0D /* Info.plist */,
 				174F80B8210924B200775D0D /* EventsAPI.swift */,
@@ -565,6 +568,7 @@
 			files = (
 				174F80AF2109229C00775D0D /* AWSAppSyncTests.swift in Sources */,
 				174F80B9210924B200775D0D /* EventsAPI.swift in Sources */,
+				741880B0213878B400523CA8 /* AuthProviderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AWSAppSyncClient/AWSAppSyncAuthProvider.swift
+++ b/AWSAppSyncClient/AWSAppSyncAuthProvider.swift
@@ -8,7 +8,7 @@ import Foundation
 // For using OIDC based authorization, this protocol needs to be implemented and passed to configuration object.
 // Use this for cases where the OIDC token needs to be fetched asynchronously and requires a callback
 public protocol AWSOIDCAuthProviderAsync: AWSOIDCAuthProvider {
-    func getLatestAuthToken(_ callback: @escaping (String) -> Void)
+    func getLatestAuthToken(_ callback: @escaping (String?, Error?) -> Void)
 }
 
 // For AuthProviders that use a callback, the getLatestAuthToken is defaulted to return an empty string

--- a/AWSAppSyncClient/AWSAppSyncAuthProvider.swift
+++ b/AWSAppSyncClient/AWSAppSyncAuthProvider.swift
@@ -6,6 +6,17 @@
 import Foundation
 
 // For using OIDC based authorization, this protocol needs to be implemented and passed to configuration object.
+// Use this for cases where the OIDC token needs to be fetched asynchronously and requires a callback
+public protocol AWSOIDCAuthProviderAsync: AWSOIDCAuthProvider {
+    func getLatestAuthToken(_ callback: @escaping (String) -> Void)
+}
+
+// For AuthProviders that use a callback, the getLatestAuthToken is defaulted to return an empty string
+extension AWSOIDCAuthProviderAsync {
+    public func getLatestAuthToken() -> String { return "" }
+}
+
+// For using OIDC based authorization, this protocol needs to be implemented and passed to configuration object.
 public protocol AWSOIDCAuthProvider {
     /// The method should fetch the token and return it to the client for using in header request.
     func getLatestAuthToken() -> String

--- a/AWSAppSyncClient/AWSAppSyncAuthProvider.swift
+++ b/AWSAppSyncClient/AWSAppSyncAuthProvider.swift
@@ -13,7 +13,7 @@ public protocol AWSOIDCAuthProviderAsync: AWSOIDCAuthProvider {
 
 // For AuthProviders that use a callback, the getLatestAuthToken is defaulted to return an empty string
 extension AWSOIDCAuthProviderAsync {
-    public func getLatestAuthToken() -> String { return "" }
+    public func getLatestAuthToken() -> String { fatalError("Callback method required") }
 }
 
 // For using OIDC based authorization, this protocol needs to be implemented and passed to configuration object.

--- a/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
+++ b/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
@@ -124,14 +124,7 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
         request.httpMethod = "POST"
         request.setValue(NSDate().aws_stringValue(AWSDateISO8601DateFormat2), forHTTPHeaderField: "X-Amz-Date")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("aws-sdk-ios/2.6.18 AppSyncClient", forHTTPHeaderField: "User-Agent")
-        if self.authType == .apiKey {
-            request.setValue(self.apiKeyAuthProvider!.getAPIKey(), forHTTPHeaderField: "x-api-key")
-        } else if self.authType == .oidcToken {
-            request.setValue(self.oidcAuthProvider!.getLatestAuthToken(), forHTTPHeaderField: "authorization")
-        } else if self.authType == .amazonCognitoUserPools {
-            request.setValue(self.userPoolsAuthProvider!.getLatestAuthToken(), forHTTPHeaderField: "authorization")
-        }
+        request.setValue("aws-sdk-ios/2.6.18 AppSyncClient", forHTTPHeaderField: "User-Agent")       
     }
     
     /// Send a data payload to a server and return a response.
@@ -186,18 +179,53 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
         
         let mutableRequest = ((request as NSURLRequest).mutableCopy() as? NSMutableURLRequest)!
         
-        if self.authType == .awsIAM {
+        sendRequestWithAuth(mutableRequest: mutableRequest, sendRequest: sendRequest)
+    }
+    
+    private func sendRequestWithAuth(mutableRequest: NSMutableURLRequest, sendRequest: @escaping (URLRequest) -> Void ) {
+        switch self.authType {
+            
+        case .awsIAM:
             let signer:AWSSignatureV4Signer = AWSSignatureV4Signer(credentialsProvider: self.credentialsProvider, endpoint: self.endpoint)
             signer.interceptRequest(mutableRequest).continueWith { _ in
                 return nil
                 }.continueWith { _ in
-                    sendRequest(request: mutableRequest as URLRequest)
+                    sendRequest(mutableRequest as URLRequest)
             }
-        } else {
-            sendRequest(request: mutableRequest as URLRequest)
+        case .apiKey:
+            mutableRequest.setValue(self.apiKeyAuthProvider!.getAPIKey(), forHTTPHeaderField: "x-api-key")
+            sendRequest( mutableRequest as URLRequest)
+        case .oidcToken:
+            if let prov = self.oidcAuthProvider as? AWSOIDCAuthProviderAsync {
+            
+                prov.getLatestAuthToken { token in
+                    if !token.isEmpty {
+                        mutableRequest.setValue(token, forHTTPHeaderField: "authorization")
+                    }
+                    sendRequest( mutableRequest as URLRequest)
+                }
+            } else if let prov = self.oidcAuthProvider {
+                 mutableRequest.setValue(prov.getLatestAuthToken(), forHTTPHeaderField: "authorization")
+            } else {
+                fatalError("Authentication provide not set")
+            }
+        case .amazonCognitoUserPools:
+            if let prov = self.userPoolsAuthProvider as? AWSOIDCAuthProviderAsync {
+                
+                prov.getLatestAuthToken { token in
+                    if !token.isEmpty {
+                        mutableRequest.setValue(token, forHTTPHeaderField: "authorization")
+                    }
+                    sendRequest( mutableRequest as URLRequest)
+                }
+            } else if let prov = self.userPoolsAuthProvider {
+                mutableRequest.setValue(prov.getLatestAuthToken(), forHTTPHeaderField: "authorization")
+            } else {
+                fatalError("Authentication provide not set")
+            }
         }
+        
     }
-    
     
     /// Send a GraphQL operation to a server and return a response for a subscription.
     ///
@@ -259,16 +287,7 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
         
         let mutableRequest = ((request as NSURLRequest).mutableCopy() as? NSMutableURLRequest)!
         
-        if self.authType == .awsIAM {
-            let signer:AWSSignatureV4Signer = AWSSignatureV4Signer(credentialsProvider: self.credentialsProvider, endpoint: self.endpoint)
-            signer.interceptRequest(mutableRequest).continueWith { _ in
-                return nil
-                }.continueWith { _ in
-                    sendRequest(request: mutableRequest as URLRequest)
-            }
-        } else {
-            sendRequest(request: mutableRequest as URLRequest)
-        }
+        sendRequestWithAuth(mutableRequest: mutableRequest, sendRequest: sendRequest)
         
         return networkTransportOperation
     }
@@ -334,16 +353,7 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
         
         let mutableRequest = ((request as NSURLRequest).mutableCopy() as? NSMutableURLRequest)!
         
-        if self.authType == .awsIAM {
-            let signer:AWSSignatureV4Signer = AWSSignatureV4Signer(credentialsProvider: self.credentialsProvider, endpoint: self.endpoint)
-            signer.interceptRequest(mutableRequest).continueWith { _ in
-                return nil
-                }.continueWith { _ in
-                    sendRequest(request: mutableRequest as URLRequest)
-            }
-        } else {
-            sendRequest(request: mutableRequest as URLRequest)
-        }
+        sendRequestWithAuth(mutableRequest: mutableRequest, sendRequest: sendRequest)
         
         return networkTransportOperation
     }

--- a/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
+++ b/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
@@ -197,30 +197,28 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
             mutableRequest.setValue(self.apiKeyAuthProvider!.getAPIKey(), forHTTPHeaderField: "x-api-key")
             sendRequest( mutableRequest as URLRequest)
         case .oidcToken:
-            if let prov = self.oidcAuthProvider as? AWSOIDCAuthProviderAsync {
+            if let provider = self.oidcAuthProvider as? AWSOIDCAuthProviderAsync {
             
-                prov.getLatestAuthToken { token in
-                    if !token.isEmpty {
-                        mutableRequest.setValue(token, forHTTPHeaderField: "authorization")
-                    }
+                provider.getLatestAuthToken { token in
+                    mutableRequest.setValue(token, forHTTPHeaderField: "authorization")
                     sendRequest( mutableRequest as URLRequest)
                 }
-            } else if let prov = self.oidcAuthProvider {
-                 mutableRequest.setValue(prov.getLatestAuthToken(), forHTTPHeaderField: "authorization")
+            } else if let provider = self.oidcAuthProvider {
+                 mutableRequest.setValue(provider.getLatestAuthToken(), forHTTPHeaderField: "authorization")
+                 sendRequest( mutableRequest as URLRequest)
             } else {
                 fatalError("Authentication provide not set")
             }
         case .amazonCognitoUserPools:
-            if let prov = self.userPoolsAuthProvider as? AWSOIDCAuthProviderAsync {
+            if let provider = self.userPoolsAuthProvider as? AWSOIDCAuthProviderAsync {
                 
-                prov.getLatestAuthToken { token in
-                    if !token.isEmpty {
-                        mutableRequest.setValue(token, forHTTPHeaderField: "authorization")
-                    }
+                provider.getLatestAuthToken { token in
+                    mutableRequest.setValue(token, forHTTPHeaderField: "authorization")
                     sendRequest( mutableRequest as URLRequest)
                 }
-            } else if let prov = self.userPoolsAuthProvider {
-                mutableRequest.setValue(prov.getLatestAuthToken(), forHTTPHeaderField: "authorization")
+            } else if let provider = self.userPoolsAuthProvider {
+                mutableRequest.setValue(provider.getLatestAuthToken(), forHTTPHeaderField: "authorization")
+                sendRequest( mutableRequest as URLRequest)
             } else {
                 fatalError("Authentication provide not set")
             }

--- a/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
+++ b/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
@@ -182,8 +182,6 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
         sendRequestWithAuth(mutableRequest: mutableRequest, sendRequest: sendRequest)
     }
     
-   
-    
     private func sendRequestWithAuth(mutableRequest: NSMutableURLRequest, sendRequest: @escaping (URLRequest) -> Void ) {        
 
         switch self.authType {

--- a/AWSAppSyncTests/AuthProviderTests.swift
+++ b/AWSAppSyncTests/AuthProviderTests.swift
@@ -1,0 +1,195 @@
+//
+// Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+import Foundation
+import XCTest
+@testable import AWSAppSync
+@testable import AWSCore
+
+// These tests validate authentication using OIDC, API Key, and Cognito User Pools.
+// For both OIDC and Cognito User pools, tokens can be fetched either synchronously
+// or via a callback.
+class AuthProviderTests: XCTestCase {
+
+    class OIDCAuthProviderAsync: AWSOIDCAuthProviderAsync {
+        var expectation: XCTestExpectation?
+        init(_ expectation: XCTestExpectation){
+            self.expectation = expectation;
+        }
+        
+        func getLatestAuthToken(_ callback: @escaping (String) -> Void) {
+            callback("CognitoUserPoolsAuthProviderAsync")
+            self.expectation?.fulfill()
+        }
+        
+    }
+    
+    class OIDCAuthProvider: AWSOIDCAuthProvider {
+        var expectation: XCTestExpectation?
+        init(_ expectation: XCTestExpectation){
+            self.expectation = expectation;
+        }
+        func getLatestAuthToken() -> String {
+            self.expectation?.fulfill()
+            return "OIDCAuthProvider"
+        }
+    }
+    
+    class CognitoUserPoolsAuthProviderAsync: AWSCognitoUserPoolsAuthProvider, AWSOIDCAuthProviderAsync {
+        
+        var expectation: XCTestExpectation?
+        init(_ expectation: XCTestExpectation){
+            self.expectation = expectation;
+        }
+        
+        func getLatestAuthToken(_ callback: @escaping (String) -> Void) {
+            callback("CognitoUserPoolsAuthProviderAsync")
+            self.expectation?.fulfill()
+        }
+        
+    }
+
+    class CognitoUserPoolsAuthProvider: AWSCognitoUserPoolsAuthProvider {
+       
+        
+        var expectation: XCTestExpectation?
+        init(_ expectation: XCTestExpectation){
+            self.expectation = expectation;
+        }
+        func getLatestAuthToken() -> String {
+            self.expectation?.fulfill()
+            return "PoolProvider"
+        }
+    }
+
+    class ApiKeyProvider: AWSAPIKeyAuthProvider {
+        var expectation: XCTestExpectation?
+        init(_ expectation: XCTestExpectation){
+            self.expectation = expectation;
+        }
+        func getAPIKey() -> String {
+            self.expectation?.fulfill()
+            return "AuthTokenTests"
+        }
+    }
+    
+    func testCanAuthenticateWithApiKey(){
+        
+        let expectation = self.expectation(description: "token retrieved")
+       
+        // The test validates that an auth token is retrieved prior to sending the request, so
+        // its ok if the URL is invalid.
+        let url = URL(string: "https://localhost")!
+        
+        let config = try? AWSAppSyncClientConfiguration(url: url,
+                                                        serviceRegion: .USEast1,
+                                                        apiKeyAuthProvider: ApiKeyProvider(expectation))
+        
+        let client = try! AWSAppSyncClient(appSyncConfig: config!)
+        let mutation = AddEventMutation(name: "test", when: "test", where: "test", description: "test")
+        
+        client.perform(mutation: mutation)        
+        
+        self.waitForExpectations(timeout: 1000, handler: nil)
+    }
+    
+    func testCanAuthenticateWithOIDCToken(){
+        
+        let expectation = self.expectation(description: "token retrieved")
+        
+        // The test validates that an auth token is retrieved prior to sending the request, so
+        // its ok if the URL is invalid.
+        let url = URL(string: "https://localhost")!
+        
+        let config = try? AWSAppSyncClientConfiguration(url: url,
+                                                       serviceRegion: .USEast1,
+                                                       oidcAuthProvider: OIDCAuthProvider(expectation))
+
+        
+        let client = try! AWSAppSyncClient(appSyncConfig: config!)
+        let mutation = AddEventMutation(name: "test", when: "test", where: "test", description: "test")
+        
+        client.perform(mutation: mutation)
+        
+        self.waitForExpectations(timeout: 1000, handler: nil)
+    }
+    
+    func testCanAuthenticateWithOIDCTokenAsync(){
+        
+        let expectation = self.expectation(description: "token retrieved")
+        
+        // The test validates that an auth token is retrieved prior to sending the request, so
+        // its ok if the URL is invalid.
+        let url = URL(string: "https://localhost")!
+        
+        let config = try? AWSAppSyncClientConfiguration(url: url,
+                                                        serviceRegion: .USEast1,
+                                                        oidcAuthProvider: OIDCAuthProviderAsync(expectation))
+        
+        
+        
+        let client = try! AWSAppSyncClient(appSyncConfig: config!)
+        let mutation = AddEventMutation(name: "test", when: "test", where: "test", description: "test")
+        
+        client.perform(mutation: mutation)
+        
+        self.waitForExpectations(timeout: 1000, handler: nil)
+    }
+    
+    func testCanAuthenticateWithCognitoUserPool(){
+        
+        let expectation = self.expectation(description: "token retrieved")
+        
+        // The test validates that an auth token is retrieved prior to sending the request, so
+        // its ok if the URL is invalid.
+        let url = URL(string: "https://localhost")!
+        
+        let config = try? AWSAppSyncClientConfiguration(url: url,
+                                                        serviceRegion: .USEast1,
+                                                        userPoolsAuthProvider: CognitoUserPoolsAuthProvider(expectation))
+        
+        
+        
+        let client = try! AWSAppSyncClient(appSyncConfig: config!)
+        let mutation = AddEventMutation(name: "test", when: "test", where: "test", description: "test")
+        
+        client.perform(mutation: mutation)
+        
+        self.waitForExpectations(timeout: 1000, handler: nil)
+    }
+    
+    func testCanAuthenticateWithCognitoUserPoolAsync(){
+        
+        let expectation = self.expectation(description: "token retrieved")
+        
+        // The test validates that an auth token is retrieved prior to sending the request, so
+        // its ok if the URL is invalid.
+        let url = URL(string: "https://localhost")!
+        
+        let config = try? AWSAppSyncClientConfiguration(url: url,
+                                                        serviceRegion: .USEast1,
+                                                        userPoolsAuthProvider: CognitoUserPoolsAuthProviderAsync(expectation))
+        
+        
+        
+        let client = try! AWSAppSyncClient(appSyncConfig: config!)
+        let mutation = AddEventMutation(name: "test", when: "test", where: "test", description: "test")
+        
+        client.perform(mutation: mutation)
+        
+        self.waitForExpectations(timeout: 1000, handler: nil)
+    }
+    
+}

--- a/AWSAppSyncTests/AuthProviderTests.swift
+++ b/AWSAppSyncTests/AuthProviderTests.swift
@@ -33,7 +33,6 @@ class AuthProviderTests: XCTestCase {
             callback("CognitoUserPoolsAuthProviderAsync")
             self.expectation?.fulfill()
         }
-        
     }
     
     class OIDCAuthProvider: AWSOIDCAuthProvider {
@@ -58,7 +57,6 @@ class AuthProviderTests: XCTestCase {
             callback("CognitoUserPoolsAuthProviderAsync")
             self.expectation?.fulfill()
         }
-        
     }
 
     class CognitoUserPoolsAuthProvider: AWSCognitoUserPoolsAuthProvider {

--- a/AWSAppSyncTests/AuthProviderTests.swift
+++ b/AWSAppSyncTests/AuthProviderTests.swift
@@ -1,5 +1,5 @@
 //
-// Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
 // You may not use this file except in compliance with the License.


### PR DESCRIPTION
This is an updated to an earlier PR that provides a backward compatible way for fetching auth tokens in a synchronous or asynchronous way.

*Description of changes:*

When using a CognitoUserPoolsAuthProvider or AWSOIDCAuthProvider, a client can create an auth provides that alternatively uses a callback:

```swift
class MyOIDCAuthProvider: AWSOIDCAuthProviderAsync {   
        func getLatestAuthToken(_ callback: @escaping (String) -> Void) {
            functionThatMakesNetworkCall(){ token in 
                callback(token)
            }
        }
    }
```

Using AWSCognitoUserPoolsAuthProvider instead:

```swift
class CognitoUserPoolsAuthProviderAsync: AWSCognitoUserPoolsAuthProvider, AWSOIDCAuthProviderAsync {
         func getLatestAuthToken(_ callback: @escaping (String) -> Void) {
            functionThatMakesNetworkCall(){ token in 
                callback(token)
            }
        }
}
```

See the AuthProviderTests.swift file for some examples. Also see [this demo project](https://github.com/JohnRbk/lambda-messenger-ios) which shows the OIDCToken generated via a network call.

In order to preserve backwards compatibility, the original AuthProvider classes were preserved and a new protocol was introduced `AWSOIDCAuthProviderAsync` which describes the callback required for classes to implement. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
