### PR TITLE
Resolved retain cycles in AWSAppSyncClient

### DIFF
--- a/AWSAppSyncClient/AWSAppSyncClient.swift
+++ b/AWSAppSyncClient/AWSAppSyncClient.swift
@@ -619,7 +619,6 @@ public class AWSAppSyncClient: NetworkConnectionNotification {
         
         self.offlineMutationExecutor = MutationExecutor(networkClient: self.httpTransport!, appSyncClient: self, snapshotProcessController: SnapshotProcessController(endpointURL:self.appSyncConfiguration.url), fileURL: self.appSyncConfiguration.databaseURL)
         networkStatusWatchers.append(self.offlineMutationExecutor!)
-        networkStatusWatchers.append(self)
         
         
         NotificationCenter.default.addObserver(self, selector: #selector(checkForReachability(note:)), name: .reachabilityChanged, object: reachability)
@@ -651,6 +650,7 @@ public class AWSAppSyncClient: NetworkConnectionNotification {
         for watchers in networkStatusWatchers {
             watchers.onNetworkAvailabilityStatusChanged(isEndpointReachable: isReachable)
         }
+        self.onNetworkAvailabilityStatusChanged(isEndpointReachable: isReachable)
     }
     
     /// Fetches a query from the server or from the local cache, depending on the current contents of the cache and the specified cache policy.

--- a/AWSAppSyncClient/AWSOfflineMutationStore.swift
+++ b/AWSAppSyncClient/AWSOfflineMutationStore.swift
@@ -139,7 +139,7 @@ class MutationExecutor: NetworkConnectionNotification {
     let isExecutingDispatchGroup = DispatchGroup()
     var currentMutation: AWSAppSyncMutationRecord?
     var networkClient: AWSNetworkTransport
-    var appSyncClient: AWSAppSyncClient
+    weak var appSyncClient: AWSAppSyncClient?
     var handlerQueue = DispatchQueue.main
     var store: ApolloStore?
     var apolloClient: ApolloClient?
@@ -232,7 +232,7 @@ class MutationExecutor: NetworkConnectionNotification {
         func notifyResultHandler(record: AWSAppSyncMutationRecord, result: JSONObject?, success: Bool, error: Error?) {
             handlerQueue.async {
                 // call master delegate
-                self.appSyncClient.offlineMutationDelegate?.mutationCallback(recordIdentifier: record.recordIdentitifer, operationString: record.operationString!, snapshot: result, error: error)
+                self.appSyncClient?.offlineMutationDelegate?.mutationCallback(recordIdentifier: record.recordIdentitifer, operationString: record.operationString!, snapshot: result, error: error)
             }
         }
         
@@ -263,7 +263,7 @@ class MutationExecutor: NetworkConnectionNotification {
         dispatchGroup.enter()
         if let s3Object = mutation.s3ObjectInput {
             
-            self.appSyncClient.s3ObjectManager!.upload(s3Object: s3Object) { (isSuccessful, error) in
+            self.appSyncClient?.s3ObjectManager!.upload(s3Object: s3Object) { (isSuccessful, error) in
                 if (isSuccessful) {
                     sendDataRequest(mutation: mutation)
                 } else {


### PR DESCRIPTION
Partially related to issue #79.

Problem:
Class `AWSAppSyncClient` sets up 2 retain cycles in its initializer which prevent deallocation.

Solution:
1. Cycle in `MutationExecutor` broken by using a `weak` reference
2. Cycle in `AWSAppSyncClient` itself broken by not adding `self` to `networkStatusWatchers` array but instead just invoking method on self directly later in code.

Verification:
A new unit test confirming `AWSAppSyncClient` gets deallocated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
