### PR TITLE
Bug fixes for avoiding retain cycles and memory leaks.

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -832,7 +832,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-AWSAppSync-AWSAppSyncTests/Pods-AWSAppSync-AWSAppSyncTests-frameworks.sh",
+				"${SRCROOT}/Pods/Target Support Files/Pods-AWSAppSync-AWSAppSyncTests/Pods-AWSAppSync-AWSAppSyncTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/AWSCore/AWSCore.framework",
 				"${BUILT_PRODUCTS_DIR}/ReachabilitySwift/Reachability.framework",
 				"${BUILT_PRODUCTS_DIR}/SQLite.swift/SQLite.framework",
@@ -845,7 +845,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AWSAppSync-AWSAppSyncTests/Pods-AWSAppSync-AWSAppSyncTests-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AWSAppSync-AWSAppSyncTests/Pods-AWSAppSync-AWSAppSyncTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		37A9334DB9AF4C4235F5D117 /* [CP] Check Pods Manifest.lock */ = {

--- a/AWSAppSyncClient.xcodeproj/xcuserdata/rohandub.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/AWSAppSyncClient.xcodeproj/xcuserdata/rohandub.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -14,6 +14,11 @@
 			<key>orderHint</key>
 			<integer>8</integer>
 		</dict>
+		<key>AWSAppSyncTestApp.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>8</integer>
+		</dict>
 		<key>AWSAppSyncTests.xcscheme</key>
 		<dict>
 			<key>orderHint</key>
@@ -30,6 +35,11 @@
 			<integer>7</integer>
 		</dict>
 		<key>StarWarsAPI.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>9</integer>
+		</dict>
+		<key>StarWarsAPI.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
 			<integer>9</integer>

--- a/AWSAppSyncClient/AWSAppSyncClient.swift
+++ b/AWSAppSyncClient/AWSAppSyncClient.swift
@@ -583,7 +583,6 @@ public class AWSAppSyncClient: NetworkConnectionNotification {
     private var offlineMuationCacheClient : AWSAppSyncOfflineMutationCache?
     private var offlineMutationExecutor: MutationExecutor?
     private var autoSubmitOfflineMutations: Bool = false
-    private var mqttClient = AWSIoTMQTTClient<AnyObject, AnyObject>()
     private var appSyncMQTTClient = AppSyncMQTTClient()
     private var subscriptionsQueue = DispatchQueue(label: "SubscriptionsQueue", qos: .userInitiated)
     

--- a/AWSAppSyncClient/MQTTSDK/AWSIoTMQTTClient.h
+++ b/AWSAppSyncClient/MQTTSDK/AWSIoTMQTTClient.h
@@ -50,7 +50,7 @@
  Delegate object that is called by the AWSIotMQTTClient object as per the AWSiOTMQTTCLientDelegate protocol to communicate changes in communication status and messages received.
  */
  
-@property(nonatomic, strong) id<AWSIoTMQTTClientDelegate> clientDelegate;
+@property(nonatomic, weak) id<AWSIoTMQTTClientDelegate> clientDelegate;
 
 /**
  Boolean flag to indicate whether auto-resubscribe feature is enabled. This flag may
@@ -97,7 +97,7 @@
 /**
  An optional associated object (nil by default).
  */
-@property(nonatomic, strong) NSObject *associatedObject;
+@property(nonatomic, weak) NSObject *associatedObject;
 
 /**
  Initalizer with the Delegate object

--- a/AWSAppSyncTests/AppSyncMQTTClientTests.swift
+++ b/AWSAppSyncTests/AppSyncMQTTClientTests.swift
@@ -69,7 +69,7 @@ class AppSyncMQTTClientTests: XCTestCase {
         
         let watcher = MockSubscriptionWatcher(topics: ["1", "2"])
         client.addWatcher(watcher: watcher, topics: watcher.getTopics(), identifier: watcher.getIdentifier())
-        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: watcher.getTopics())])
+        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: watcher.getTopics())], identifier: "1")
         
         wait(for: [expectation], timeout: 2)
     }
@@ -92,13 +92,13 @@ class AppSyncMQTTClientTests: XCTestCase {
         let watcher0 = MockSubscriptionWatcher(topics: ["1", "2"])
         
         client.addWatcher(watcher: watcher0, topics: watcher0.getTopics(), identifier: watcher0.getIdentifier())
-        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: watcher0.getTopics())])
+        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: watcher0.getTopics())], identifier: "1")
         
         let watcher1 = MockSubscriptionWatcher(topics: ["2", "3"])
         
         let allTopics = [watcher0.getTopics(), watcher1.getTopics()].flatMap({ $0 })
         client.addWatcher(watcher: watcher1, topics: watcher1.getTopics(), identifier: watcher1.getIdentifier())
-        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: allTopics)])
+        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: allTopics)], identifier: "1")
             
         wait(for: [expectation], timeout: 2)
     }
@@ -121,7 +121,7 @@ class AppSyncMQTTClientTests: XCTestCase {
         let unwantedTopics = ["3"]
         
         client.addWatcher(watcher: watcher, topics: watcher.getTopics(), identifier: watcher.getIdentifier())
-        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: unwantedTopics)])
+        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: unwantedTopics)], identifier: "1")
         
         wait(for: [expectation], timeout: 2)
     }
@@ -143,7 +143,7 @@ class AppSyncMQTTClientTests: XCTestCase {
         let topics = ["2", "3"]
         
         client.addWatcher(watcher: watcher, topics: watcher.getTopics(), identifier: watcher.getIdentifier())
-        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: topics)])
+        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: topics)], identifier: "1")
         
         wait(for: [expectation], timeout: 2)
     }
@@ -171,12 +171,12 @@ class AppSyncMQTTClientTests: XCTestCase {
         
         autoreleasepool {
             let deallocBlock: (MQTTSubscritionWatcher) -> Void = { (object) in
-                client.stopSubscription(subscription: object)
+                client.stopSubscription(subscription: object, subscriptionId: "1")
             }
             
             let watcher = MockSubscriptionWatcher(topics: ["1", "2"], deallocBlock: deallocBlock)
             client.addWatcher(watcher: watcher, topics: watcher.getTopics(), identifier: watcher.getIdentifier())
-            client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: watcher.topics)])
+            client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: watcher.topics)], identifier: "1")
             weakWatcher = watcher
             
             wait(for: [connectExpectation], timeout: 2)
@@ -220,7 +220,7 @@ class AppSyncMQTTClientTests: XCTestCase {
         let topics = ["2", "3"]
         
         client.addWatcher(watcher: watcher, topics: watcher.getTopics(), identifier: watcher.getIdentifier())
-        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: topics)])
+        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: topics)], identifier: "1")
         
         wait(for: [connectExpectation], timeout: 5)
         
@@ -258,7 +258,7 @@ class AppSyncMQTTClientTests: XCTestCase {
         let watcher = MockSubscriptionWatcher(topics: ["1"], disconnectCallbackBlock: disconnectCallbackBlock)
         
         client.addWatcher(watcher: watcher, topics: watcher.getTopics(), identifier: watcher.getIdentifier())
-        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: watcher.getTopics())])
+        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: watcher.getTopics())], identifier: "1")
         
         wait(for: [connectExpectation], timeout: 2)
         
@@ -295,7 +295,7 @@ class AppSyncMQTTClientTests: XCTestCase {
         let watcher = MockSubscriptionWatcher(topics: ["1"], messageCallbackBlock: messageCallbackBlock)
         
         client.addWatcher(watcher: watcher, topics: watcher.getTopics(), identifier: watcher.getIdentifier())
-        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: watcher.getTopics())])
+        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: watcher.getTopics())], identifier: "1")
         
         wait(for: [connectExpectation], timeout: 2)
         
@@ -328,11 +328,11 @@ class AppSyncMQTTClientTests: XCTestCase {
         let watcher = MockSubscriptionWatcher(topics: ["1", "2"])
         
         client.addWatcher(watcher: watcher, topics: watcher.getTopics(), identifier: watcher.getIdentifier())
-        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: watcher.topics)])
+        client.startSubscriptions(subscriptionInfo: [AWSSubscriptionInfo(clientId: "1", url: "url", topics: watcher.topics)], identifier: "1")
         
         wait(for: [expectation], timeout: 2)
         
-        client.stopSubscription(subscription: watcher)
+        client.stopSubscription(subscription: watcher, subscriptionId: "1")
         
         wait(for: [disconnectExpectation], timeout: 2)
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The AWS AppSync SDK for iOS enables you to access your AWS AppSync backend and perform operations like `Queries`, `Mutations` and `Subscriptions`. The SDK also includes support for offline operations.
 
+## 2.6.23
+
+### Bug Fixes
+
+* Resolved retain cycles in AWSAppSyncClient which allow the instance to be deallocated. [See PR#88](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/pull/88) Thanks @ifabijanovic 🎉
+* Resolved retain cycle in underlying MQTT client. [Source](https://github.com/aws/aws-sdk-ios/pull/1037)
+
 ## 2.6.22
 
 ### Enhancements


### PR DESCRIPTION
## Description
Fixes issues reported in #82 

Avoid retain cycles and memory leaks in MQTT SDK. 

## Testing
Validated changes by running all functional tests and also verified through Xcode's memory graph using a sample app.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
