### PR TITLE
Fix Issue 91 - Handle network errors and timeouts

### DIFF
--- a/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
+++ b/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
@@ -195,6 +195,8 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
                         } else {
                             completionHandler(nil, error)
                         }
+                    } else {
+                        completionHandler(nil, error)
                     }
                     return
                 }


### PR DESCRIPTION
*Issue #91*

*Description of changes:*
Handle errors that are not `AWSAppSyncClientError` errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
