### PR TITLE
Update ReachabilitySwift to 4.3.0 in Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
 github "aws/aws-sdk-ios" ~> 2.7.0
 github "stephencelis/SQLite.swift" ~> 0.11.4
-github "ashleymills/Reachability.swift" ~> 0.4.0
+github "ashleymills/Reachability.swift" ~> 4.3.0


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Previously, this resolved to the "v3" tag. This change will ensure that both Carthage and CocoaPods versions are built with the same ReachabilitySwift version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
