### PR TITLE
Update SyncConfiguration parameter for sync method.

### DIFF
--- a/AWSAppSyncClient/AppSyncSubscriptionWithSync.swift
+++ b/AWSAppSyncClient/AppSyncSubscriptionWithSync.swift
@@ -19,13 +19,13 @@ public class SyncConfiguration {
         return seconds
     }
     
-    public init(seconds: Int) {
-        self.seconds = seconds
+    public init(baseRefreshIntervalInSeconds: Int) {
+        self.seconds = baseRefreshIntervalInSeconds
     }
     
     // utility for setting default sync to 1 day
     public class func defaultSyncConfiguration() -> SyncConfiguration {
-        return SyncConfiguration(seconds: 86400)
+        return SyncConfiguration(baseRefreshIntervalInSeconds: 86400)
     }
 }
 

--- a/AWSAppSyncTests/AWSAppSyncAPIKeyAuthTests.swift
+++ b/AWSAppSyncTests/AWSAppSyncAPIKeyAuthTests.swift
@@ -310,7 +310,7 @@ class AWSAppSyncAPIKeyAuthTests: XCTestCase {
             subscriptionExpectation.fulfill()
         }, deltaQuery: query, deltaQueryResultHandler: { (result, transaction, error) in
             // set up sync configuration to be 10 seconds to test if base query gets called again.
-        }, syncConfiguration: SyncConfiguration(seconds: 10))
+        }, syncConfiguration: SyncConfiguration(baseRefreshIntervalInSeconds: 10))
         
         XCTAssertNotNil(syncWatcher, "sync watcher expected to be non nil.")
         
@@ -352,7 +352,7 @@ class AWSAppSyncAPIKeyAuthTests: XCTestCase {
         }, deltaQuery: query, deltaQueryResultHandler: { (result, transaction, error) in
             // set up sync configuration to be 10 seconds to test if base query gets called again.
             deltaQueryCallbackExpectation.fulfill()
-        }, syncConfiguration: SyncConfiguration(seconds: 15))
+        }, syncConfiguration: SyncConfiguration(baseRefreshIntervalInSeconds: 15))
         
         XCTAssertNotNil(syncWatcher, "sync watcher expected to be non nil.")
         


### PR DESCRIPTION
*Description of changes:*

Rename sync parameter to `baseRefreshIntervalInSeconds`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
