### PR TITLE
Replace `random` with Swift 4.2 version

### DIFF
--- a/AWSAppSyncClient/AWSAppSyncRetryHandler.swift
+++ b/AWSAppSyncClient/AWSAppSyncRetryHandler.swift
@@ -60,6 +60,6 @@ internal class AWSAppSyncRetryHandler {
     }
     
     static func getRandomBetween0And1() -> Float {
-        return Float(arc4random()) / Float(UINT32_MAX)
+        return Float.random(in: 0...1)
     }
 }


### PR DESCRIPTION
Replace `random` with Swift 4.2 version