### PR TITLE
Fix valid architectures

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -1931,7 +1931,6 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;
-				VALID_ARCHS = "armv7 arm64 armv7s";
 			};
 			name = Debug;
 		};
@@ -1957,7 +1956,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 4.2;
-				VALID_ARCHS = "armv7 arm64 armv7s";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

Currently for some reason valid architectures are only "armv7 arm64 armv7s", but for example the latest Xcode 10 supports `arm64e`.  I think that valid architectures should be default that Xcode sets if there're no any specific reasons.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.