### PR TITLE
Remove dependencies from cartfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The AWS AppSync SDK for iOS enables you to access your AWS AppSync backend and perform operations like `Queries`, `Mutations` and `Subscriptions`. The SDK also includes support for offline operations.
 
+## 2.9.3
+
+### Misc. Updates
+
+* Removed dependencies from the Cartfile to eliminate unnecessary dependency downloads and reduce build times, as well as reduce confusion about which version of a dependency is actually in use. The canonical source of downloaded dependencies is the Podfile.lock, checked into source. See [Issues #76](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/76), [PR #158](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/pull/158)
+
 ## 2.9.2
 
 ### New Features

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
-github "aws/aws-sdk-ios" ~> 2.8.0
-github "stephencelis/SQLite.swift" ~> 0.11.5
-github "ashleymills/Reachability.swift" ~> 4.3.0
+# Dependencies for this project are managed via CocoaPods and checked into source.
+# Please see Podfile.lock and Pods directory for the in-use versions.


### PR DESCRIPTION
*Issue #, if available:*
#76

*Description of changes:*
Removes dependencies from `Cartfile` and points people to the Podfile.lock for a canonical list of downloadable dependencies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
