### PR TITLE
Remove unused contentMap field from persistent queue. Fixes #33.

### DIFF
--- a/AWSAppSyncClient/AWSSQLLiteNormalizedCache.swift
+++ b/AWSAppSyncClient/AWSSQLLiteNormalizedCache.swift
@@ -35,7 +35,6 @@ public final class AWSMutationCache {
     private let id = Expression<Int64>("_id")
     private let recordIdentifier = Expression<CacheKey>("recordIdentifier")
     private let data = Expression<Data>("data")
-    private let contentMap = Expression<String>("contentMap")
     private let recordState = Expression<String>("recordState")
     private let timestamp = Expression<Date>("timestamp")
     private let s3Bucket = Expression<String?>("s3Bucket")
@@ -56,7 +55,6 @@ public final class AWSMutationCache {
             table.column(id, primaryKey: .autoincrement)
             table.column(recordIdentifier, unique: true)
             table.column(data)
-            table.column(contentMap)
             table.column(recordState)
             table.column(timestamp)
             table.column(s3Bucket)
@@ -75,7 +73,6 @@ public final class AWSMutationCache {
             let insert = mutationRecords.insert(
                 recordIdentifier <- record.recordIdentitifer,
                 data <- record.data!,
-                contentMap <- record.contentMap!.description,
                 recordState <- record.recordState.rawValue,
                 timestamp <- record.timestamp,
                 s3Bucket <- s3Object.bucket,
@@ -89,7 +86,6 @@ public final class AWSMutationCache {
             let insert = mutationRecords.insert(
                 recordIdentifier <- record.recordIdentitifer,
                 data <- record.data!,
-                contentMap <- record.contentMap!.description,
                 recordState <- record.recordState.rawValue,
                 timestamp <- record.timestamp,
                 operationString <- record.operationString!)

--- a/AWSAppSyncIntegrationTests/ConsoleResources/appsync-integrationtests-cloudformation.yaml
+++ b/AWSAppSyncIntegrationTests/ConsoleResources/appsync-integrationtests-cloudformation.yaml
@@ -128,6 +128,7 @@ Resources:
 
           deletePostUsingParameters(id: ID!): Post
 
+          testMutationWithoutParameters: Boolean
         }
 
         type Post {
@@ -363,6 +364,16 @@ Resources:
           Ref: AWS::Region
         UseCallerCredentials: FALSE
 
+  NoneDatasource:
+    Type: AWS::AppSync::DataSource
+    Properties:
+      Type: NONE
+      Name: none
+      ApiId:
+        Fn::GetAtt:
+        - GraphQLApi
+        - ApiId
+      ServiceRoleArn: !GetAtt DynamoDBRole.Arn
 
   #########################################################
   # AWS AppSync Resolvers
@@ -433,6 +444,31 @@ Resources:
           $util.error($ctx.error.message, $ctx.error.type)
         #end
         $util.toJson($ctx.result.items)
+
+  TestMutationWithoutParametersResolver:
+    Type: AWS::AppSync::Resolver
+    Properties:
+      ApiId: !GetAtt GraphQLApi.ApiId
+      TypeName: "Mutation"
+      FieldName: "testMutationWithoutParameters"
+      DataSourceName: !GetAtt NoneDatasource.Name
+      RequestMappingTemplate: |
+        #**
+          Resolvers with None data sources can locally publish events
+          that fire subscriptions without hitting a backend data source.
+          The value of 'payload' after the template has been evaluated
+          will be directly forwarded to the response.
+        *#
+        {
+          "version": "2017-02-28",
+          "payload": {
+            "body": "${context.arguments.body}",
+            "from": "${context.identity.username}",
+            "to":  "${context.arguments.to}",
+            "sentAt": "$util.time.nowISO8601()"
+          }
+        }
+      ResponseMappingTemplate: "$util.toJson(true)"
 
   ListPostsDeltaResolver:
     Type: "AWS::AppSync::Resolver"

--- a/AWSAppSyncTestCommon/AppSyncTestAPI.swift
+++ b/AWSAppSyncTestCommon/AppSyncTestAPI.swift
@@ -5,7 +5,7 @@ import AWSAppSync
 public struct CreatePostWithFileInput: GraphQLMapConvertible {
   public var graphQLMap: GraphQLMap
 
-  public init(author: String, title: String, content: String, url: Optional<String?> = nil, ups: Optional<Int?> = nil, downs: Optional<Int?> = nil, file: S3ObjectInput) {
+  public init(author: String, title: String, content: String, url: String? = nil, ups: Int? = nil, downs: Int? = nil, file: S3ObjectInput) {
     graphQLMap = ["author": author, "title": title, "content": content, "url": url, "ups": ups, "downs": downs, "file": file]
   }
 
@@ -36,27 +36,27 @@ public struct CreatePostWithFileInput: GraphQLMapConvertible {
     }
   }
 
-  public var url: Optional<String?> {
+  public var url: String? {
     get {
-      return graphQLMap["url"] as! Optional<String?>
+      return graphQLMap["url"] as! String?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "url")
     }
   }
 
-  public var ups: Optional<Int?> {
+  public var ups: Int? {
     get {
-      return graphQLMap["ups"] as! Optional<Int?>
+      return graphQLMap["ups"] as! Int?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "ups")
     }
   }
 
-  public var downs: Optional<Int?> {
+  public var downs: Int? {
     get {
-      return graphQLMap["downs"] as! Optional<Int?>
+      return graphQLMap["downs"] as! Int?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "downs")
@@ -158,7 +158,7 @@ public enum DeltaAction: RawRepresentable, Equatable, JSONDecodable, JSONEncodab
 public struct CreatePostWithoutFileInput: GraphQLMapConvertible {
   public var graphQLMap: GraphQLMap
 
-  public init(author: String, title: String, content: String, url: Optional<String?> = nil, ups: Optional<Int?> = nil, downs: Optional<Int?> = nil) {
+  public init(author: String, title: String, content: String, url: String? = nil, ups: Int? = nil, downs: Int? = nil) {
     graphQLMap = ["author": author, "title": title, "content": content, "url": url, "ups": ups, "downs": downs]
   }
 
@@ -189,27 +189,27 @@ public struct CreatePostWithoutFileInput: GraphQLMapConvertible {
     }
   }
 
-  public var url: Optional<String?> {
+  public var url: String? {
     get {
-      return graphQLMap["url"] as! Optional<String?>
+      return graphQLMap["url"] as! String?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "url")
     }
   }
 
-  public var ups: Optional<Int?> {
+  public var ups: Int? {
     get {
-      return graphQLMap["ups"] as! Optional<Int?>
+      return graphQLMap["ups"] as! Int?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "ups")
     }
   }
 
-  public var downs: Optional<Int?> {
+  public var downs: Int? {
     get {
-      return graphQLMap["downs"] as! Optional<Int?>
+      return graphQLMap["downs"] as! Int?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "downs")
@@ -220,7 +220,7 @@ public struct CreatePostWithoutFileInput: GraphQLMapConvertible {
 public struct UpdatePostWithFileInput: GraphQLMapConvertible {
   public var graphQLMap: GraphQLMap
 
-  public init(id: GraphQLID, author: Optional<String?> = nil, title: Optional<String?> = nil, content: Optional<String?> = nil, url: Optional<String?> = nil, ups: Optional<Int?> = nil, downs: Optional<Int?> = nil, file: S3ObjectInput) {
+  public init(id: GraphQLID, author: String? = nil, title: String? = nil, content: String? = nil, url: String? = nil, ups: Int? = nil, downs: Int? = nil, file: S3ObjectInput) {
     graphQLMap = ["id": id, "author": author, "title": title, "content": content, "url": url, "ups": ups, "downs": downs, "file": file]
   }
 
@@ -233,54 +233,54 @@ public struct UpdatePostWithFileInput: GraphQLMapConvertible {
     }
   }
 
-  public var author: Optional<String?> {
+  public var author: String? {
     get {
-      return graphQLMap["author"] as! Optional<String?>
+      return graphQLMap["author"] as! String?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "author")
     }
   }
 
-  public var title: Optional<String?> {
+  public var title: String? {
     get {
-      return graphQLMap["title"] as! Optional<String?>
+      return graphQLMap["title"] as! String?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "title")
     }
   }
 
-  public var content: Optional<String?> {
+  public var content: String? {
     get {
-      return graphQLMap["content"] as! Optional<String?>
+      return graphQLMap["content"] as! String?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "content")
     }
   }
 
-  public var url: Optional<String?> {
+  public var url: String? {
     get {
-      return graphQLMap["url"] as! Optional<String?>
+      return graphQLMap["url"] as! String?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "url")
     }
   }
 
-  public var ups: Optional<Int?> {
+  public var ups: Int? {
     get {
-      return graphQLMap["ups"] as! Optional<Int?>
+      return graphQLMap["ups"] as! Int?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "ups")
     }
   }
 
-  public var downs: Optional<Int?> {
+  public var downs: Int? {
     get {
-      return graphQLMap["downs"] as! Optional<Int?>
+      return graphQLMap["downs"] as! Int?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "downs")
@@ -300,7 +300,7 @@ public struct UpdatePostWithFileInput: GraphQLMapConvertible {
 public struct UpdatePostWithoutFileInput: GraphQLMapConvertible {
   public var graphQLMap: GraphQLMap
 
-  public init(id: GraphQLID, author: Optional<String?> = nil, title: Optional<String?> = nil, content: Optional<String?> = nil, url: Optional<String?> = nil, ups: Optional<Int?> = nil, downs: Optional<Int?> = nil) {
+  public init(id: GraphQLID, author: String? = nil, title: String? = nil, content: String? = nil, url: String? = nil, ups: Int? = nil, downs: Int? = nil) {
     graphQLMap = ["id": id, "author": author, "title": title, "content": content, "url": url, "ups": ups, "downs": downs]
   }
 
@@ -313,54 +313,54 @@ public struct UpdatePostWithoutFileInput: GraphQLMapConvertible {
     }
   }
 
-  public var author: Optional<String?> {
+  public var author: String? {
     get {
-      return graphQLMap["author"] as! Optional<String?>
+      return graphQLMap["author"] as! String?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "author")
     }
   }
 
-  public var title: Optional<String?> {
+  public var title: String? {
     get {
-      return graphQLMap["title"] as! Optional<String?>
+      return graphQLMap["title"] as! String?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "title")
     }
   }
 
-  public var content: Optional<String?> {
+  public var content: String? {
     get {
-      return graphQLMap["content"] as! Optional<String?>
+      return graphQLMap["content"] as! String?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "content")
     }
   }
 
-  public var url: Optional<String?> {
+  public var url: String? {
     get {
-      return graphQLMap["url"] as! Optional<String?>
+      return graphQLMap["url"] as! String?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "url")
     }
   }
 
-  public var ups: Optional<Int?> {
+  public var ups: Int? {
     get {
-      return graphQLMap["ups"] as! Optional<Int?>
+      return graphQLMap["ups"] as! Int?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "ups")
     }
   }
 
-  public var downs: Optional<Int?> {
+  public var downs: Int? {
     get {
-      return graphQLMap["downs"] as! Optional<Int?>
+      return graphQLMap["downs"] as! Int?
     }
     set {
       graphQLMap.updateValue(newValue, forKey: "downs")
@@ -3140,6 +3140,41 @@ public final class DeletePostUsingParametersMutation: GraphQLMutation {
             snapshot.updateValue(newValue, forKey: "region")
           }
         }
+      }
+    }
+  }
+}
+
+public final class TestMutationWithoutParametersMutation: GraphQLMutation {
+  public static let operationString =
+    "mutation TestMutationWithoutParameters {\n  testMutationWithoutParameters\n}"
+
+  public init() {
+  }
+
+  public struct Data: GraphQLSelectionSet {
+    public static let possibleTypes = ["Mutation"]
+
+    public static let selections: [GraphQLSelection] = [
+      GraphQLField("testMutationWithoutParameters", type: .scalar(Bool.self)),
+    ]
+
+    public var snapshot: Snapshot
+
+    public init(snapshot: Snapshot) {
+      self.snapshot = snapshot
+    }
+
+    public init(testMutationWithoutParameters: Bool? = nil) {
+      self.init(snapshot: ["__typename": "Mutation", "testMutationWithoutParameters": testMutationWithoutParameters])
+    }
+
+    public var testMutationWithoutParameters: Bool? {
+      get {
+        return snapshot["testMutationWithoutParameters"] as? Bool
+      }
+      set {
+        snapshot.updateValue(newValue, forKey: "testMutationWithoutParameters")
       }
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The AWS AppSync SDK for iOS enables you to access your AWS AppSync backend and p
 ### Bug fixes
 
 * Merged Apollo iOS [PR #427](https://github.com/apollographql/apollo-ios/pull/427) to fix incompatibility with EnumeratedIterator in latest Xcode 10.2 beta.
+* Fixed an issue where performing a mutation with no parameters would crash clients using a backing database. [Issue #33](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/33)
 
 ## 2.9.2
 


### PR DESCRIPTION
*Issue #, if available:*

Fixes #33 

*Description of changes:*

Removed unused `contentMap` column from persistent store. This field was nil for mutations that have no parameters, and was crashing upon force-unwrap.

Updated CloudFormation template to include a `TestMutationWithoutParametersMutation` type to support these tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
