### PR TITLE
Prepopulate records table with empty QUERY_ROOT (#92)

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		DF9468DB20E1CA4A00E40482 /* AWSNetworkTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9468DA20E1CA4A00E40482 /* AWSNetworkTransport.swift */; };
 		E4EA2880833EDE9A29FEBC15 /* Pods_AWSAppSync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 621AB86198B779E235D8B962 /* Pods_AWSAppSync.framework */; };
 		F4DE2BE323727AA52DA01C3E /* Pods_AWSAppSyncUnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F0FC364F581CF82AB0F22F9D /* Pods_AWSAppSyncUnitTests.framework */; };
+		FA00595A221222D800BFBD13 /* MutationOptimisticUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA005959221222D800BFBD13 /* MutationOptimisticUpdateTests.swift */; };
 		FA0C12BB21CD308A00B438CB /* AWSAppSyncClientConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0C12B921CD2FFB00B438CB /* AWSAppSyncClientConfiguration.swift */; };
 		FA0C12BF21CD360B00B438CB /* AWSAppSyncAuthType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0C12BE21CD360B00B438CB /* AWSAppSyncAuthType.swift */; };
 		FA0C12C121CD3BB200B438CB /* BasicAWSAPIKeyAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0C12C021CD3BB200B438CB /* BasicAWSAPIKeyAuthProvider.swift */; };
@@ -426,6 +427,7 @@
 		E1F00FE81687698CFF36300B /* Pods-AWSAppSync-AWSAppSyncTestCommon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSync-AWSAppSyncTestCommon.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSync-AWSAppSyncTestCommon/Pods-AWSAppSync-AWSAppSyncTestCommon.debug.xcconfig"; sourceTree = "<group>"; };
 		EEFAF48F41FE68936AC4A8C2 /* Pods-AWSAppSyncIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSyncIntegrationTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSyncIntegrationTests/Pods-AWSAppSyncIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F0FC364F581CF82AB0F22F9D /* Pods_AWSAppSyncUnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSAppSyncUnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA005959221222D800BFBD13 /* MutationOptimisticUpdateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutationOptimisticUpdateTests.swift; sourceTree = "<group>"; };
 		FA0C12B321CBEE7B00B438CB /* MockAWSNetworkTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSNetworkTransport.swift; sourceTree = "<group>"; };
 		FA0C12B521CC2C9B00B438CB /* MockCancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCancellable.swift; sourceTree = "<group>"; };
 		FA0C12B721CC33F300B438CB /* MockS3ObjectManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockS3ObjectManager.swift; sourceTree = "<group>"; };
@@ -843,6 +845,7 @@
 				FAF5D78A21D3EFA600FC04D2 /* AWSAppSyncServiceConfigTests.swift */,
 				FAE1E0EE21D3DC9A005767C7 /* Foundation+UtilsTests.swift */,
 				FA8C62B521D6E3AA00FF9924 /* Info.plist */,
+				FA005959221222D800BFBD13 /* MutationOptimisticUpdateTests.swift */,
 				FA38636D21DD8FF200DBA2BC /* MutationQueueTests.swift */,
 				FA88834621E3D05800DEBCB3 /* ReachabilityChangeNotifierTests.swift */,
 				FAD17C7021C2ABEA008D116C /* SubscriptionMessagesQueueTests.swift */,
@@ -1577,6 +1580,7 @@
 				FAE7948621D6EAE70032D37F /* Foundation+UtilsTests.swift in Sources */,
 				FABD707122050EDF00C99B47 /* AWSAppSyncClientConfigurationTestsWithDatabaseURL.swift in Sources */,
 				FABD70752205101600C99B47 /* AWSAppSyncClientInfoTests.swift in Sources */,
+				FA00595A221222D800BFBD13 /* MutationOptimisticUpdateTests.swift in Sources */,
 				FA1A620C21E6533A00AA54D0 /* AWSAppSyncRetryHandlerTests.swift in Sources */,
 				FA38636E21DD8FF200DBA2BC /* MutationQueueTests.swift in Sources */,
 				FA4F0D9821D6EDA50099D165 /* SyncStrategyTests.swift in Sources */,

--- a/AWSAppSyncUnitTests/MutationOptimisticUpdateTests.swift
+++ b/AWSAppSyncUnitTests/MutationOptimisticUpdateTests.swift
@@ -1,0 +1,344 @@
+//
+// Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+import XCTest
+@testable import AWSAppSync
+@testable import AWSAppSyncTestCommon
+
+class MutationOptimisticUpdateTests: XCTestCase {
+    static let fetchQueue = DispatchQueue(label: "MutationOptimisticUpdateTests.fetch")
+    static let mutationQueue = DispatchQueue(label: "MutationOptimisticUpdateTests.mutations")
+
+    var cacheConfigRootDirectory: URL!
+    let mockHTTPTransport = MockAWSNetworkTransport()
+
+    // Set up a new DB for each test
+    override func setUp() {
+        let tempDir = FileManager.default.temporaryDirectory
+        cacheConfigRootDirectory = tempDir.appendingPathComponent("MutationOptimisticUpdateTests-\(UUID().uuidString)")
+    }
+
+    override func tearDown() {
+        MockReachabilityProvidingFactory.clearShared()
+        NetworkReachabilityNotifier.clearShared()
+    }
+
+    func testMutation_WithOptimisticUpdate_UpdatesEmptyPersistentCache() throws {
+        try doMutationWithOptimisticUpdate(usingBackingDatabase: true)
+    }
+
+    func testMutation_WithOptimisticUpdate_UpdatesEmptyInMemoryCache() throws {
+        try doMutationWithOptimisticUpdate(usingBackingDatabase: false)
+    }
+
+    func testMutation_WithoutOptimisticUpdate_DoesNotUpdateEmptyCache() throws {
+        let addPost = DefaultTestPostData.defaultCreatePostWithoutFileUsingParametersMutation
+
+        // We will set up a response block that never actually invokes the completion handler. This allows us to
+        // examine the state of the local cache before any return values are processed
+        let nonDispatchingResponseBlockInvoked = expectation(description: "Non dispatching response block invoked")
+
+        let nonDispatchingResponseBlock: SendOperationResponseBlock<CreatePostWithoutFileUsingParametersMutation> = {
+            _, _ in
+            nonDispatchingResponseBlockInvoked.fulfill()
+        }
+
+        mockHTTPTransport.sendOperationResponseQueue.append(nonDispatchingResponseBlock)
+
+        let appSyncClient = try makeAppSyncClient(using: mockHTTPTransport)
+
+        appSyncClient.perform(mutation: addPost, queue: MutationOptimisticUpdateTests.mutationQueue)
+
+        let cacheDoesNotHaveOptimisticUpdateResult = expectation(description: "Cache does not return optimistic update result")
+
+        appSyncClient.fetch(
+            query: ListPostsQuery(),
+            cachePolicy: .returnCacheDataDontFetch,
+            queue: MutationOptimisticUpdateTests.fetchQueue
+        ) { result, error in
+            guard error == nil else {
+                XCTFail("Unexpected error querying cache: \(error.debugDescription)")
+                return
+            }
+
+            guard result?.data?.listPosts == nil else {
+                XCTFail("Result unexpectedly not-nil querying optimistically updated cache: \(result.debugDescription)")
+                return
+            }
+
+            cacheDoesNotHaveOptimisticUpdateResult.fulfill()
+        }
+
+        wait(
+            for: [
+                nonDispatchingResponseBlockInvoked,
+                cacheDoesNotHaveOptimisticUpdateResult
+            ],
+            timeout: 1.0)
+    }
+
+    func testMutation_WithOptimisticUpdate_UpdatesPopulatedCache() throws {
+        let addPost = DefaultTestPostData.defaultCreatePostWithoutFileUsingParametersMutation
+
+        // First response should be a query response from the "server" that will populate the local cache.
+        let idFromServer = "FROM-SERVER-\(UUID().uuidString)"
+        let serverResponse = makeListPostsResponseBody(withId: idFromServer)
+        mockHTTPTransport.sendOperationResponseQueue.append(serverResponse)
+
+        // We will set up a response block that never actually invokes the completion handler. This allows us to
+        // examine the state of the local cache before any return values are processed
+        let nonDispatchingResponseBlockInvoked = expectation(description: "Non dispatching response block invoked")
+
+        let nonDispatchingResponseBlock: SendOperationResponseBlock<CreatePostWithoutFileUsingParametersMutation> = {
+            _, _ in
+            nonDispatchingResponseBlockInvoked.fulfill()
+        }
+
+        mockHTTPTransport.sendOperationResponseQueue.append(nonDispatchingResponseBlock)
+
+        let appSyncClient = try makeAppSyncClient(using: mockHTTPTransport)
+
+        let initialQueryPerformed = expectation(description: "Initial listPosts query performed")
+        // Note that we specify a `.fetchIgnoringCacheData` policy to ensure we only get our mocked response,
+        // which Apoll will write to the cache
+        appSyncClient.fetch(query: ListPostsQuery(), cachePolicy: .fetchIgnoringCacheData, queue: MutationOptimisticUpdateTests.fetchQueue) { result, error in
+            defer {
+                initialQueryPerformed.fulfill()
+            }
+            guard error == nil else {
+                XCTFail("Unexpected error performing initial query: \(error!.localizedDescription)")
+                return
+            }
+
+            let foo = result?.data?.listPosts
+        }
+
+        wait(for: [initialQueryPerformed], timeout: 1.0)
+
+        let idFromOptimisticUpdate = "TEMPORARY-\(UUID().uuidString)"
+        let newPost = ListPostsQuery.Data.ListPost(
+            id: idFromOptimisticUpdate,
+            author: addPost.author,
+            title: addPost.title,
+            content: addPost.content,
+            ups: addPost.ups ?? 0,
+            downs: addPost.downs ?? 0)
+
+        let optimisticUpdatePerformed = expectation(description: "Optimistic update performed")
+        appSyncClient.perform(
+            mutation: addPost,
+            queue: MutationOptimisticUpdateTests.mutationQueue,
+            optimisticUpdate: { transaction in
+                guard let transaction = transaction else {
+                    XCTFail("Optimistic update transaction unexpectedly nil")
+                    return
+                }
+
+                do {
+                    try transaction.update(query: ListPostsQuery()) { data in
+                        guard var listPosts = data.listPosts else {
+                            XCTFail("listPosts unexpectedly nil in optimistic update--expecting results of initial query")
+                            return
+                        }
+                        listPosts.append(newPost)
+                        data.listPosts = listPosts
+                    }
+                    // The `update` is synchronous, so we can fulfill after the block completes
+                    optimisticUpdatePerformed.fulfill()
+                } catch {
+                    XCTFail("Unexpected error performing optimistic update: \(error)")
+                }
+        })
+
+        let fetchFromCacheComplete = expectation(description: "Fetch from cache is complete")
+
+        appSyncClient.fetch(
+            query: ListPostsQuery(),
+            cachePolicy: .returnCacheDataDontFetch,
+            queue: MutationOptimisticUpdateTests.fetchQueue
+        ) { result, error in
+            defer {
+                fetchFromCacheComplete.fulfill()
+            }
+
+            guard error == nil else {
+                XCTFail("Unexpected error querying optimistically updated cache: \(error.debugDescription)")
+                return
+            }
+
+            guard
+                let listPosts = result?.data?.listPosts
+                else {
+                    XCTFail("Result unexpectedly nil querying optimistically updated cache")
+                    return
+            }
+
+            let posts = listPosts.compactMap({$0})
+            // Don't assert the order;
+            XCTAssertNotNil(posts.first { $0.id == idFromServer })
+            XCTAssertNotNil(posts.first { $0.id == idFromOptimisticUpdate })
+        }
+
+        wait(
+            for: [
+                nonDispatchingResponseBlockInvoked,
+                optimisticUpdatePerformed,
+                fetchFromCacheComplete
+            ],
+            timeout: 1.0)
+    }
+
+    // MARK - Utility methods
+
+    func doMutationWithOptimisticUpdate(usingBackingDatabase: Bool) throws {
+        let addPost = DefaultTestPostData.defaultCreatePostWithoutFileUsingParametersMutation
+
+        // We will set up a response block that never actually invokes the completion handler. This allows us to
+        // examine the state of the local cache before any return values are processed
+        let nonDispatchingResponseBlockInvoked = expectation(description: "Non dispatching response block invoked")
+
+        let nonDispatchingResponseBlock: SendOperationResponseBlock<CreatePostWithoutFileUsingParametersMutation> = {
+            _, _ in
+            nonDispatchingResponseBlockInvoked.fulfill()
+        }
+
+        mockHTTPTransport.sendOperationResponseQueue.append(nonDispatchingResponseBlock)
+
+        let appSyncClient = try makeAppSyncClient(using: mockHTTPTransport, withBackingDatabase: usingBackingDatabase)
+
+        let newPost = ListPostsQuery.Data.ListPost(
+            id: "TEMPORARY-\(UUID().uuidString)",
+            author: addPost.author,
+            title: addPost.title,
+            content: addPost.content,
+            ups: addPost.ups ?? 0,
+            downs: addPost.downs ?? 0)
+
+        let optimisticUpdatePerformed = expectation(description: "Optimistic update performed")
+        appSyncClient.perform(
+            mutation: addPost,
+            queue: MutationOptimisticUpdateTests.mutationQueue,
+            optimisticUpdate: { transaction in
+                guard let transaction = transaction else {
+                    XCTFail("Optimistic update transaction unexpectedly nil")
+                    return
+                }
+                do {
+                    try transaction.update(query: ListPostsQuery()) { data in
+                        var listPosts: [ListPostsQuery.Data.ListPost?] = data.listPosts ?? []
+                        listPosts.append(newPost)
+                        data.listPosts = listPosts
+                    }
+                    // The `update` is synchronous, so we can fulfill after the block completes
+                    optimisticUpdatePerformed.fulfill()
+                } catch {
+                    XCTFail("Unexpected error performing optimistic update: \(error)")
+                }
+        })
+
+        let cacheHasOptimisticUpdateResult = expectation(description: "Cache returns optimistic update result")
+
+        appSyncClient.fetch(
+            query: ListPostsQuery(),
+            cachePolicy: .returnCacheDataDontFetch,
+            queue: MutationOptimisticUpdateTests.fetchQueue
+        ) { result, error in
+            guard error == nil else {
+                XCTFail("Unexpected error querying optimistically updated cache: \(error.debugDescription)")
+                return
+            }
+
+            guard
+                let listPosts = result?.data?.listPosts
+                else {
+                    XCTFail("Result unexpectedly nil querying optimistically updated cache")
+                    return
+            }
+
+            let posts = listPosts.compactMap({$0})
+            guard let firstPost = posts.first else {
+                XCTFail("No posts in optimistically updated cache result")
+                return
+            }
+
+            XCTAssertEqual(firstPost.id, newPost.id)
+            cacheHasOptimisticUpdateResult.fulfill()
+        }
+
+        wait(
+            for: [
+                nonDispatchingResponseBlockInvoked,
+                optimisticUpdatePerformed,
+                cacheHasOptimisticUpdateResult
+            ],
+            timeout: 1.0)
+    }
+
+    func makeAddPostResponseBody(withId id: GraphQLID,
+                                 forMutation mutation: CreatePostWithoutFileUsingParametersMutation) -> JSONObject {
+        let createdDateMilliseconds = Date().timeIntervalSince1970 * 1000
+
+        let response = CreatePostWithoutFileUsingParametersMutation.Data.CreatePostWithoutFileUsingParameter(
+            id: id,
+            author: mutation.author,
+            title: mutation.title,
+            content: mutation.content,
+            url: mutation.url,
+            ups: mutation.ups ?? 0,
+            downs: mutation.downs ?? 0,
+            file: nil,
+            createdDate: String(describing: Int(createdDateMilliseconds)),
+            awsDs: nil)
+        return ["data": ["createPostWithoutFileUsingParameters": response.jsonObject]]
+    }
+
+    func makeListPostsResponseBody(withId id: GraphQLID) -> JSONObject {
+        let createdDateMilliseconds = Date().timeIntervalSince1970 * 1000
+        let post = ListPostsQuery.Data.ListPost(id: id,
+                                                author: "Test author",
+                                                title: "Test Post",
+                                                content: "Test Content",
+                                                url: "http://test.com",
+                                                ups: 0,
+                                                downs: 0,
+                                                file: nil,
+                                                createdDate: String(describing: Int(createdDateMilliseconds)),
+                                                awsDs: nil)
+        let response = ListPostsQuery.Data(listPosts: [post])
+        return [
+            "data": response.jsonObject
+        ]
+    }
+
+    func makeAppSyncClient(using httpTransport: AWSNetworkTransport,
+                           withBackingDatabase useBackingDatabase: Bool = true) throws -> DeinitNotifiableAppSyncClient {
+        let cacheConfiguration: AWSAppSyncCacheConfiguration? = useBackingDatabase ? try AWSAppSyncCacheConfiguration(withRootDirectory: cacheConfigRootDirectory) : nil
+        let helper = try AppSyncClientTestHelper(
+            with: .apiKey,
+            testConfiguration: AppSyncClientTestConfiguration.forUnitTests,
+            cacheConfiguration: cacheConfiguration,
+            httpTransport: httpTransport,
+            reachabilityFactory: MockReachabilityProvidingFactory.self
+        )
+
+        if let cacheConfiguration = cacheConfiguration {
+            print("AppSyncClient created with cacheConfiguration: \(cacheConfiguration)")
+        } else {
+            print("AppSyncClient created with in-memory caches")
+        }
+        return helper.appSyncClient
+    }
+
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The AWS AppSync SDK for iOS enables you to access your AWS AppSync backend and perform operations like `Queries`, `Mutations` and `Subscriptions`. The SDK also includes support for offline operations.
 
+## 2.10.1
+
+### Bug fixes
+
+- Prepopulate the queries cache with an empty "QUERY_ROOT" record, to allow optimistic updates of the cache where no queries have been previously performed. ([Issue #92](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/92))
+
+### Misc. Updates
+
+- Updated CloudFormation template to include S3 buckets and associated configuration to support complex object integration tests, and added integration tests for S3 uploads and downloads.
+
 ## 2.10.0
 
 ### Bug fixes


### PR DESCRIPTION
*Issue #, if available:*

#92 

*Description of changes:*

Prepopulated both AWSSQLiteNormalizedCache and InMemoryNormalizedCache with an empty QUERY_ROOT record to allow optimistic updates of empty caches. Works around an Apollo behavior that is arguably a bug, but that I'm reluctant to change for fear of unintended side effects in the rest of the handling. See discussion on #92.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
