### PR TITLE
Resolve cache-miss behavior for AppSync-modified Apollo client

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -118,6 +118,8 @@
 		E4EA2880833EDE9A29FEBC15 /* Pods_AWSAppSync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 621AB86198B779E235D8B962 /* Pods_AWSAppSync.framework */; };
 		F4DE2BE323727AA52DA01C3E /* Pods_AWSAppSyncUnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F0FC364F581CF82AB0F22F9D /* Pods_AWSAppSyncUnitTests.framework */; };
 		FA00595A221222D800BFBD13 /* MutationOptimisticUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA005959221222D800BFBD13 /* MutationOptimisticUpdateTests.swift */; };
+		FA005A982214E20A00BFBD13 /* FetchQueryTestsSimple.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA005A972214E20A00BFBD13 /* FetchQueryTestsSimple.swift */; };
+		FA005AA02216137C00BFBD13 /* FetchQueryTestsComplex.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA005A9F2216137C00BFBD13 /* FetchQueryTestsComplex.swift */; };
 		FA0C12BB21CD308A00B438CB /* AWSAppSyncClientConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0C12B921CD2FFB00B438CB /* AWSAppSyncClientConfiguration.swift */; };
 		FA0C12BF21CD360B00B438CB /* AWSAppSyncAuthType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0C12BE21CD360B00B438CB /* AWSAppSyncAuthType.swift */; };
 		FA0C12C121CD3BB200B438CB /* BasicAWSAPIKeyAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0C12C021CD3BB200B438CB /* BasicAWSAPIKeyAuthProvider.swift */; };
@@ -428,6 +430,8 @@
 		EEFAF48F41FE68936AC4A8C2 /* Pods-AWSAppSyncIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSyncIntegrationTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSyncIntegrationTests/Pods-AWSAppSyncIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F0FC364F581CF82AB0F22F9D /* Pods_AWSAppSyncUnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSAppSyncUnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA005959221222D800BFBD13 /* MutationOptimisticUpdateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutationOptimisticUpdateTests.swift; sourceTree = "<group>"; };
+		FA005A972214E20A00BFBD13 /* FetchQueryTestsSimple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchQueryTestsSimple.swift; sourceTree = "<group>"; };
+		FA005A9F2216137C00BFBD13 /* FetchQueryTestsComplex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchQueryTestsComplex.swift; sourceTree = "<group>"; };
 		FA0C12B321CBEE7B00B438CB /* MockAWSNetworkTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAWSNetworkTransport.swift; sourceTree = "<group>"; };
 		FA0C12B521CC2C9B00B438CB /* MockCancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCancellable.swift; sourceTree = "<group>"; };
 		FA0C12B721CC33F300B438CB /* MockS3ObjectManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockS3ObjectManager.swift; sourceTree = "<group>"; };
@@ -557,26 +561,28 @@
 		1700503721543E41008B16B6 /* ApolloTests */ = {
 			isa = PBXGroup;
 			children = (
-				17005076215445BD008B16B6 /* FetchQueryTests.swift */,
-				17005079215445BE008B16B6 /* LoadQueryFromStoreTests.swift */,
-				17005077215445BE008B16B6 /* ReadWriteFromStoreTests.swift */,
-				17005078215445BE008B16B6 /* WatchQueryTests.swift */,
-				1700506D21544011008B16B6 /* MockNetworkTransport.swift */,
-				1700506A21544011008B16B6 /* TestCacheProvider.swift */,
-				1700506B21544011008B16B6 /* XCTAssertHelpers.swift */,
-				1700506C21544011008B16B6 /* XCTestCase+Promise.swift */,
 				1700505E21543F94008B16B6 /* BatchedLoadTests.swift */,
 				1700505621543F94008B16B6 /* CacheKeyForFieldTests.swift */,
 				1700505C21543F94008B16B6 /* DataLoaderTests.swift */,
+				17005076215445BD008B16B6 /* FetchQueryTests.swift */,
+				FA005A9F2216137C00BFBD13 /* FetchQueryTestsComplex.swift */,
+				FA005A972214E20A00BFBD13 /* FetchQueryTestsSimple.swift */,
 				1700505521543F94008B16B6 /* FragmentConstructionAndConversionTests.swift */,
+				1700503A21543E41008B16B6 /* Info.plist */,
 				1700505921543F94008B16B6 /* InputValueEncodingTests.swift */,
+				17005079215445BE008B16B6 /* LoadQueryFromStoreTests.swift */,
+				1700506D21544011008B16B6 /* MockNetworkTransport.swift */,
 				1700505D21543F94008B16B6 /* MutatingResultsTests.swift */,
 				1700505721543F94008B16B6 /* NormalizeQueryResults.swift */,
 				1700505421543F94008B16B6 /* ParseQueryResponseTests.swift */,
 				1700505A21543F94008B16B6 /* PromiseTests.swift */,
 				1700505821543F94008B16B6 /* ReadFieldValueTests.swift */,
+				17005077215445BE008B16B6 /* ReadWriteFromStoreTests.swift */,
 				1700505B21543F94008B16B6 /* ResultOrPromiseTests.swift */,
-				1700503A21543E41008B16B6 /* Info.plist */,
+				1700506A21544011008B16B6 /* TestCacheProvider.swift */,
+				17005078215445BE008B16B6 /* WatchQueryTests.swift */,
+				1700506B21544011008B16B6 /* XCTAssertHelpers.swift */,
+				1700506C21544011008B16B6 /* XCTestCase+Promise.swift */,
 			);
 			path = ApolloTests;
 			sourceTree = "<group>";
@@ -1447,7 +1453,9 @@
 				1700506421543F94008B16B6 /* InputValueEncodingTests.swift in Sources */,
 				1700506921543F94008B16B6 /* BatchedLoadTests.swift in Sources */,
 				1700506F21544011008B16B6 /* XCTAssertHelpers.swift in Sources */,
+				FA005AA02216137C00BFBD13 /* FetchQueryTestsComplex.swift in Sources */,
 				1700507B215445BE008B16B6 /* ReadWriteFromStoreTests.swift in Sources */,
+				FA005A982214E20A00BFBD13 /* FetchQueryTestsSimple.swift in Sources */,
 				1700506221543F94008B16B6 /* NormalizeQueryResults.swift in Sources */,
 				1700505F21543F94008B16B6 /* ParseQueryResponseTests.swift in Sources */,
 				1700506021543F94008B16B6 /* FragmentConstructionAndConversionTests.swift in Sources */,

--- a/AWSAppSyncClient/Apollo/Sources/Apollo/GraphQLResult.swift
+++ b/AWSAppSyncClient/Apollo/Sources/Apollo/GraphQLResult.swift
@@ -11,7 +11,7 @@ public struct GraphQLResult<Data> {
   /// A list of errors, or `nil` if the operation completed without encountering any errors.
   public let errors: [GraphQLError]?
   /// Source of data
-  public let source:Source
+  public let source: Source
     
   let dependentKeys: Set<CacheKey>?
   

--- a/ApolloTests/FetchQueryTests.swift
+++ b/ApolloTests/FetchQueryTests.swift
@@ -11,6 +11,7 @@ class FetchQueryTests: XCTestCase {
       "hero": [
         "name": "R2-D2",
         "__typename": "Droid",
+        "optionalString": NSNull()
       ]
     ]
 
@@ -21,7 +22,8 @@ class FetchQueryTests: XCTestCase {
         "data": [
           "hero": [
             "name": "Luke Skywalker",
-            "__typename": "Human"
+            "__typename": "Human",
+            "optionalString": NSNull()
           ]
         ]
         ])
@@ -50,6 +52,7 @@ class FetchQueryTests: XCTestCase {
       "hero": [
         "name": "R2-D2",
         "__typename": "Droid",
+        "optionalString": NSNull()
       ]
     ]
     
@@ -60,7 +63,8 @@ class FetchQueryTests: XCTestCase {
         "data": [
           "hero": [
             "name": "Luke Skywalker",
-            "__typename": "Human"
+            "__typename": "Human",
+            "optionalString": NSNull()
           ]
         ]
         ])
@@ -92,6 +96,7 @@ class FetchQueryTests: XCTestCase {
       "QUERY_ROOT.hero": [
         "name": "R2-D2",
         "__typename": "Droid",
+        "optionalString": NSNull()
       ]
     ]
 
@@ -102,7 +107,8 @@ class FetchQueryTests: XCTestCase {
         "data": [
           "hero": [
             "name": "Luke Skywalker",
-            "__typename": "Human"
+            "__typename": "Human",
+            "optionalString": NSNull()
           ]
         ]
         ])
@@ -130,6 +136,7 @@ class FetchQueryTests: XCTestCase {
       "QUERY_ROOT": ["hero": Reference(key: "hero")],
       "hero": [
         "name": "R2-D2",
+        "optionalString": NSNull()
       ]
     ]
 
@@ -140,7 +147,8 @@ class FetchQueryTests: XCTestCase {
         "data": [
           "hero": [
             "name": "Luke Skywalker",
-            "__typename": "Human"
+            "__typename": "Human",
+            "optionalString": NSNull()
           ]
         ]
         ])
@@ -169,6 +177,7 @@ class FetchQueryTests: XCTestCase {
       "hero": [
         "name": "R2-D2",
         "__typename": "Droid",
+        "optionalString": NSNull()
       ]
     ]
 
@@ -179,7 +188,8 @@ class FetchQueryTests: XCTestCase {
         "data": [
           "hero": [
             "name": "Luke Skywalker",
-            "__typename": "Human"
+            "__typename": "Human",
+            "optionalString": NSNull()
           ]
         ]
         ])
@@ -207,6 +217,7 @@ class FetchQueryTests: XCTestCase {
       "QUERY_ROOT": ["hero": Reference(key: "hero")],
       "hero": [
         "name": "R2-D2",
+        "optionalString": NSNull()
       ]
     ]
 
@@ -217,7 +228,8 @@ class FetchQueryTests: XCTestCase {
         "data": [
           "hero": [
             "name": "Luke Skywalker",
-            "__typename": "Human"
+            "__typename": "Human",
+            "optionalString": NSNull()
           ]
         ]
         ])
@@ -249,7 +261,8 @@ class FetchQueryTests: XCTestCase {
       "data": [
         "hero": [
           "name": "Luke Skywalker",
-          "__typename": "Human"
+          "__typename": "Human",
+          "optionalString": NSNull()
         ]
       ]
     ])

--- a/ApolloTests/FetchQueryTestsComplex.swift
+++ b/ApolloTests/FetchQueryTestsComplex.swift
@@ -1,0 +1,269 @@
+import XCTest
+@testable import AWSAppSync
+import StarWarsAPI
+
+// Test cache behavior for complex queries. These tests have been run against the unmodified Apollo codebase to ensure
+// that AppSync maintains the same caching hit/miss behavior.
+class ComplexQueryFetchTests: XCTestCase {
+
+    struct InitialCacheRecords {
+        static let cacheHit: RecordSet = [
+            "QUERY_ROOT": [
+                "hero": Reference(key: "hero"),
+                "hero(episode:EMPIRE)": Reference(key: "hero(episode:EMPIRE)")
+            ],
+            "hero": ["__typename": "Droid", "name": "R2-D2 Cache"],
+            "hero(episode:EMPIRE)": ["__typename": "Human", "name": "Luke Skywalker Cache"]
+        ]
+
+        static let emptyCache: RecordSet = [:]
+
+        static let queryRoot: RecordSet = ["QUERY_ROOT": [:]]
+
+        static let missingData: RecordSet = [
+            "QUERY_ROOT": [
+                "hero": Reference(key: "hero"),
+            ],
+            "hero": ["__typename": "Droid", "name": "R2-D2 Cache"]
+        ]
+
+        private init() {}
+    }
+
+    let mockNetworkTransport = MockNetworkTransport(body: [
+        "data": [
+            "r2": ["__typename": "Droid", "name": "R2-D2 Server"],
+            "luke": ["__typename": "Human", "name": "Luke Skywalker Server"]
+        ]
+        ])
+
+    // MARK: - fetchIgnoringCacheData
+
+    func testFetchIgnoringCacheData_cacheHit() throws {
+        try doTestFetchIgnoringCacheData(with: InitialCacheRecords.cacheHit)
+    }
+
+    func testFetchIgnoringCacheData_cacheMissEmptyCache() throws {
+        try doTestFetchIgnoringCacheData(with: InitialCacheRecords.emptyCache)
+    }
+
+    func testFetchIgnoringCacheData_cacheMissQueryRootOnly() throws {
+        try doTestFetchIgnoringCacheData(with: InitialCacheRecords.queryRoot)
+    }
+
+    func testFetchIgnoringCacheData_cacheMissMissingData() throws {
+        try doTestFetchIgnoringCacheData(with: InitialCacheRecords.missingData)
+    }
+
+    func doTestFetchIgnoringCacheData(with initialRecords: RecordSet) throws {
+        let query = TwoHeroesQuery()
+
+        withCache(initialRecords: initialRecords) { cache in
+            let store = ApolloStore(cache: cache)
+
+            let client = ApolloClient(networkTransport: mockNetworkTransport, store: store)
+
+            let expectation = self.expectation(description: "Fetching query")
+
+            client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { (result, error) in
+                defer { expectation.fulfill() }
+
+                guard let result = result else { XCTFail("No query result");  return }
+
+                XCTAssertEqual(result.data?.luke?.name, "Luke Skywalker Server")
+                XCTAssertEqual(result.data?.r2?.name, "R2-D2 Server")
+            }
+
+            self.waitForExpectations(timeout: 5, handler: nil)
+        }
+    }
+
+    // MARK: - returnCacheDataAndFetch
+
+    func testReturnCacheDataAndFetchCacheHit() throws {
+        let query = TwoHeroesQuery()
+
+        withCache(initialRecords: InitialCacheRecords.cacheHit) { cache in
+            let store = ApolloStore(cache: cache)
+
+            let client = ApolloClient(networkTransport: mockNetworkTransport, store: store)
+
+            let cacheResultExpectation = self.expectation(description: "Query result from cache")
+            let serverResultExpectation = self.expectation(description: "Query result from server")
+
+            client.fetch(query: query, cachePolicy: .returnCacheDataAndFetch) { (result, error) in
+                switch (result?.data?.r2?.name, result?.data?.luke?.name) {
+                case ("R2-D2 Cache", "Luke Skywalker Cache"):
+                    cacheResultExpectation.fulfill()
+                case ("R2-D2 Server", "Luke Skywalker Server"):
+                    serverResultExpectation.fulfill()
+                default:
+                    XCTFail("Unexpected or nil result: \(String(describing: result))")
+                }
+            }
+
+            self.waitForExpectations(timeout: 5, handler: nil)
+        }
+    }
+
+    func testReturnCacheDataAndFetch_emptyCache() throws {
+        try doTestReturnCacheDataAndFetchCacheMiss(with: InitialCacheRecords.emptyCache)
+    }
+
+    func testReturnCacheDataAndFetch_missingData() throws {
+        try doTestReturnCacheDataAndFetchCacheMiss(with: InitialCacheRecords.missingData)
+    }
+
+    func testReturnCacheDataAndFetch_queryRoot() throws {
+        try doTestReturnCacheDataAndFetchCacheMiss(with: InitialCacheRecords.queryRoot)
+    }
+
+    func doTestReturnCacheDataAndFetchCacheMiss(with initialRecords: RecordSet) throws {
+        let query = TwoHeroesQuery()
+
+        withCache(initialRecords: initialRecords) { cache in
+            let store = ApolloStore(cache: cache)
+
+            let client = ApolloClient(networkTransport: mockNetworkTransport, store: store)
+
+            let serverResultExpectation = self.expectation(description: "Query result from server")
+
+            client.fetch(query: query, cachePolicy: .returnCacheDataAndFetch) { (result, error) in
+                let isLukeResultFromCache = result?.data?.luke?.name.hasSuffix("Cache") ?? false
+                let isR2ResultFromCache = result?.data?.r2?.name.hasSuffix("Cache") ?? false
+
+                if isLukeResultFromCache || isR2ResultFromCache {
+                    XCTFail("Unexpectedly got cached result for a cache miss test")
+                    return
+                }
+
+                if result?.data?.luke?.name == "Luke Skywalker Server" && result?.data?.r2?.name == "R2-D2 Server" {
+                    serverResultExpectation.fulfill()
+                } else {
+                    XCTFail("Unexpected or nil result: \(String(describing: result))")
+                }
+            }
+
+            self.waitForExpectations(timeout: 5, handler: nil)
+        }
+    }
+
+    // MARK: - returnCacheDataElseFetch
+
+    func testReturnCacheDataElseFetchCacheHit() throws {
+        let query = TwoHeroesQuery()
+
+        withCache(initialRecords: InitialCacheRecords.cacheHit) { (cache) in
+            let store = ApolloStore(cache: cache)
+
+            let client = ApolloClient(networkTransport: mockNetworkTransport, store: store)
+
+            let expectation = self.expectation(description: "Fetching query")
+
+            client.fetch(query: query, cachePolicy: .returnCacheDataElseFetch) { (result, error) in
+                defer { expectation.fulfill() }
+
+                guard let result = result else { XCTFail("No query result");  return }
+
+                XCTAssertEqual(result.data?.r2?.name, "R2-D2 Cache")
+                XCTAssertEqual(result.data?.luke?.name, "Luke Skywalker Cache")
+            }
+
+            self.waitForExpectations(timeout: 5, handler: nil)
+        }
+    }
+
+    func testReturnCacheDataElseFetch_emptyCache() throws {
+        try doTestReturnCacheDataElseFetchCacheMiss(with: InitialCacheRecords.emptyCache)
+    }
+
+    func testReturnCacheDataElseFetch_missingData() throws {
+        try doTestReturnCacheDataElseFetchCacheMiss(with: InitialCacheRecords.missingData)
+    }
+
+    func testReturnCacheDataElseFetch_queryRoot() throws {
+        try doTestReturnCacheDataElseFetchCacheMiss(with: InitialCacheRecords.queryRoot)
+    }
+
+    func doTestReturnCacheDataElseFetchCacheMiss(with initialRecords: RecordSet) throws {
+        let query = TwoHeroesQuery()
+
+        withCache(initialRecords: initialRecords) { (cache) in
+            let store = ApolloStore(cache: cache)
+
+            let client = ApolloClient(networkTransport: mockNetworkTransport, store: store)
+
+            let expectation = self.expectation(description: "Fetching query")
+
+            client.fetch(query: query, cachePolicy: .returnCacheDataElseFetch) { (result, error) in
+                defer { expectation.fulfill() }
+
+                guard let result = result else { XCTFail("No query result");  return }
+
+                XCTAssertEqual(result.data?.luke?.name, "Luke Skywalker Server")
+                XCTAssertEqual(result.data?.r2?.name, "R2-D2 Server")
+            }
+
+            self.waitForExpectations(timeout: 5, handler: nil)
+        }
+    }
+
+    // MARK: - returnCacheDataDontFetch
+
+    func testReturnCacheDataDontFetchCacheHit() throws {
+        let query = TwoHeroesQuery()
+
+        withCache(initialRecords: InitialCacheRecords.cacheHit) { (cache) in
+            let store = ApolloStore(cache: cache)
+
+            let client = ApolloClient(networkTransport: mockNetworkTransport, store: store)
+
+            let expectation = self.expectation(description: "Fetching query")
+
+            client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { (result, error) in
+                defer { expectation.fulfill() }
+
+                guard let result = result else { XCTFail("No query result");  return }
+
+                XCTAssertEqual(result.data?.r2?.name, "R2-D2 Cache")
+                XCTAssertEqual(result.data?.luke?.name, "Luke Skywalker Cache")
+            }
+
+            self.waitForExpectations(timeout: 5, handler: nil)
+        }
+    }
+
+    func testReturnCacheDataDontFetch_emptyCache() throws {
+        try doTestReturnCacheDataDontFetchCacheMiss(with: InitialCacheRecords.emptyCache)
+    }
+
+    func testReturnCacheDataDontFetch_missingData() throws {
+        try doTestReturnCacheDataDontFetchCacheMiss(with: InitialCacheRecords.missingData)
+    }
+
+    func testReturnCacheDataDontFetch_queryRoot() throws {
+        try doTestReturnCacheDataDontFetchCacheMiss(with: InitialCacheRecords.queryRoot)
+    }
+
+    func doTestReturnCacheDataDontFetchCacheMiss(with initialRecords: RecordSet) throws {
+        let query = TwoHeroesQuery()
+
+        withCache(initialRecords: initialRecords) { (cache) in
+            let store = ApolloStore(cache: cache)
+
+            let client = ApolloClient(networkTransport: mockNetworkTransport, store: store)
+
+            let expectation = self.expectation(description: "Fetching query")
+
+            client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { (result, error) in
+                defer { expectation.fulfill() }
+
+                XCTAssertNil(error)
+                XCTAssertNil(result)
+            }
+
+            self.waitForExpectations(timeout: 5, handler: nil)
+        }
+    }
+
+}

--- a/ApolloTests/FetchQueryTestsSimple.swift
+++ b/ApolloTests/FetchQueryTestsSimple.swift
@@ -6,12 +6,12 @@ import StarWarsAPI
 // the cache with an empty QUERY_ROOT. Note that there is some overlap between this and FetchQueryTests, but we're
 // allowing it to localize the changes without significantly modifying the Apollo-provided test code. These tests have
 // been run against the unmodified Apollo codebase to ensure that AppSync maintains the same caching hit/miss behavior.
-class SimpleQueryFetchTests: XCTestCase {
+class FetchQueryTestsSimple: XCTestCase {
 
     struct InitialCacheRecords {
         static let cacheHit: RecordSet = [
             "QUERY_ROOT": ["hero": Reference(key: "hero")],
-            "hero": [ "name": "R2-D2", "__typename": "Droid" ]
+            "hero": [ "name": "R2-D2", "__typename": "Droid", "optionalString": NSNull()]
         ]
 
         static let emptyCache: RecordSet = [:]
@@ -20,7 +20,7 @@ class SimpleQueryFetchTests: XCTestCase {
 
         static let missingData: RecordSet = [
             "QUERY_ROOT": ["hero": Reference(key: "hero")],
-            "hero": [ "name": "R2-D2" ]
+            "hero": [ "name": "R2-D2", "optionalString": NSNull()]
         ]
 
         private init() {}
@@ -28,7 +28,7 @@ class SimpleQueryFetchTests: XCTestCase {
 
     let mockNetworkTransport = MockNetworkTransport(body: [
         "data": [
-            "hero": [ "name": "Luke Skywalker", "__typename": "Human" ]
+            "hero": [ "name": "Luke Skywalker", "__typename": "Human", "optionalString": NSNull()]
         ]
         ])
 
@@ -66,6 +66,7 @@ class SimpleQueryFetchTests: XCTestCase {
                 guard let result = result else { XCTFail("No query result");  return }
 
                 XCTAssertEqual(result.data?.hero?.name, "Luke Skywalker")
+                XCTAssertNil(result.data?.hero?.optionalString)
             }
 
             self.waitForExpectations(timeout: 5, handler: nil)
@@ -247,4 +248,5 @@ class SimpleQueryFetchTests: XCTestCase {
             self.waitForExpectations(timeout: 5, handler: nil)
         }
     }
+
 }

--- a/ApolloTests/FetchQueryTestsSimple.swift
+++ b/ApolloTests/FetchQueryTestsSimple.swift
@@ -1,0 +1,250 @@
+import XCTest
+@testable import AWSAppSync
+import StarWarsAPI
+
+// Expands Apollo's "FetchQueryTests" with more cache miss coverage, including a test for AppSync's pre-population of
+// the cache with an empty QUERY_ROOT. Note that there is some overlap between this and FetchQueryTests, but we're
+// allowing it to localize the changes without significantly modifying the Apollo-provided test code. These tests have
+// been run against the unmodified Apollo codebase to ensure that AppSync maintains the same caching hit/miss behavior.
+class SimpleQueryFetchTests: XCTestCase {
+
+    struct InitialCacheRecords {
+        static let cacheHit: RecordSet = [
+            "QUERY_ROOT": ["hero": Reference(key: "hero")],
+            "hero": [ "name": "R2-D2", "__typename": "Droid" ]
+        ]
+
+        static let emptyCache: RecordSet = [:]
+
+        static let queryRoot: RecordSet = ["QUERY_ROOT": [:]]
+
+        static let missingData: RecordSet = [
+            "QUERY_ROOT": ["hero": Reference(key: "hero")],
+            "hero": [ "name": "R2-D2" ]
+        ]
+
+        private init() {}
+    }
+
+    let mockNetworkTransport = MockNetworkTransport(body: [
+        "data": [
+            "hero": [ "name": "Luke Skywalker", "__typename": "Human" ]
+        ]
+        ])
+
+    // MARK: - fetchIgnoringCacheData
+
+    func testFetchIgnoringCacheData_cacheHit() throws {
+        try doTestFetchIgnoringCacheData(with: InitialCacheRecords.cacheHit)
+    }
+
+    func testFetchIgnoringCacheData_cacheMissEmptyCache() throws {
+        try doTestFetchIgnoringCacheData(with: InitialCacheRecords.emptyCache)
+    }
+
+    func testFetchIgnoringCacheData_cacheMissQueryRootOnly() throws {
+        try doTestFetchIgnoringCacheData(with: InitialCacheRecords.queryRoot)
+    }
+
+    func testFetchIgnoringCacheData_cacheMissMissingData() throws {
+        try doTestFetchIgnoringCacheData(with: InitialCacheRecords.missingData)
+    }
+
+    func doTestFetchIgnoringCacheData(with initialRecords: RecordSet) throws {
+        let query = HeroNameQuery()
+
+        withCache(initialRecords: initialRecords) { cache in
+            let store = ApolloStore(cache: cache)
+
+            let client = ApolloClient(networkTransport: mockNetworkTransport, store: store)
+
+            let expectation = self.expectation(description: "Fetching query")
+
+            client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { (result, error) in
+                defer { expectation.fulfill() }
+
+                guard let result = result else { XCTFail("No query result");  return }
+
+                XCTAssertEqual(result.data?.hero?.name, "Luke Skywalker")
+            }
+
+            self.waitForExpectations(timeout: 5, handler: nil)
+        }
+    }
+
+    // MARK: - returnCacheDataAndFetch
+
+    func testReturnCacheDataAndFetchCacheHit() throws {
+        let query = HeroNameQuery()
+
+        withCache(initialRecords: InitialCacheRecords.cacheHit) { cache in
+            let store = ApolloStore(cache: cache)
+
+            let client = ApolloClient(networkTransport: mockNetworkTransport, store: store)
+
+            let cacheResultExpectation = self.expectation(description: "Query result from cache")
+            let serverResultExpectation = self.expectation(description: "Query result from server")
+
+            client.fetch(query: query, cachePolicy: .returnCacheDataAndFetch) { (result, error) in
+                if result?.data?.hero?.name == "R2-D2" {
+                    cacheResultExpectation.fulfill()
+                } else if result?.data?.hero?.name == "Luke Skywalker" {
+                    serverResultExpectation.fulfill()
+                } else {
+                    XCTFail("Unexpected or nil result: \(String(describing: result))")
+                }
+            }
+
+            self.waitForExpectations(timeout: 5, handler: nil)
+        }
+    }
+
+    func testReturnCacheDataAndFetch_emptyCache() throws {
+        try doTestReturnCacheDataAndFetchCacheMiss(with: InitialCacheRecords.emptyCache)
+    }
+
+    func testReturnCacheDataAndFetch_missingData() throws {
+        try doTestReturnCacheDataAndFetchCacheMiss(with: InitialCacheRecords.missingData)
+    }
+
+    func testReturnCacheDataAndFetch_queryRoot() throws {
+        try doTestReturnCacheDataAndFetchCacheMiss(with: InitialCacheRecords.queryRoot)
+    }
+
+    func doTestReturnCacheDataAndFetchCacheMiss(with initialRecords: RecordSet) throws {
+        let query = HeroNameQuery()
+
+        withCache(initialRecords: initialRecords) { cache in
+            let store = ApolloStore(cache: cache)
+
+            let client = ApolloClient(networkTransport: mockNetworkTransport, store: store)
+
+            let serverResultExpectation = self.expectation(description: "Query result from server")
+
+            client.fetch(query: query, cachePolicy: .returnCacheDataAndFetch) { (result, error) in
+                if result?.data?.hero?.name == "Luke Skywalker" {
+                    serverResultExpectation.fulfill()
+                } else {
+                    XCTFail("Unexpected or nil result: \(String(describing: result))")
+                }
+            }
+
+            self.waitForExpectations(timeout: 5, handler: nil)
+        }
+    }
+
+    // MARK: - returnCacheDataElseFetch
+
+    func testReturnCacheDataElseFetchCacheHit() throws {
+        let query = HeroNameQuery()
+
+        withCache(initialRecords: InitialCacheRecords.cacheHit) { (cache) in
+            let store = ApolloStore(cache: cache)
+
+            let client = ApolloClient(networkTransport: mockNetworkTransport, store: store)
+
+            let expectation = self.expectation(description: "Fetching query")
+
+            client.fetch(query: query, cachePolicy: .returnCacheDataElseFetch) { (result, error) in
+                defer { expectation.fulfill() }
+
+                guard let result = result else { XCTFail("No query result");  return }
+
+                XCTAssertEqual(result.data?.hero?.name, "R2-D2")
+            }
+
+            self.waitForExpectations(timeout: 5, handler: nil)
+        }
+    }
+
+    func testReturnCacheDataElseFetch_emptyCache() throws {
+        try doTestReturnCacheDataElseFetchCacheMiss(with: InitialCacheRecords.emptyCache)
+    }
+
+    func testReturnCacheDataElseFetch_missingData() throws {
+        try doTestReturnCacheDataElseFetchCacheMiss(with: InitialCacheRecords.missingData)
+    }
+
+    func testReturnCacheDataElseFetch_queryRoot() throws {
+        try doTestReturnCacheDataElseFetchCacheMiss(with: InitialCacheRecords.queryRoot)
+    }
+
+    func doTestReturnCacheDataElseFetchCacheMiss(with initialRecords: RecordSet) throws {
+        let query = HeroNameQuery()
+
+        withCache(initialRecords: initialRecords) { (cache) in
+            let store = ApolloStore(cache: cache)
+
+            let client = ApolloClient(networkTransport: mockNetworkTransport, store: store)
+
+            let expectation = self.expectation(description: "Fetching query")
+
+            client.fetch(query: query, cachePolicy: .returnCacheDataElseFetch) { (result, error) in
+                defer { expectation.fulfill() }
+
+                guard let result = result else { XCTFail("No query result");  return }
+
+                XCTAssertEqual(result.data?.hero?.name, "Luke Skywalker")
+            }
+
+            self.waitForExpectations(timeout: 5, handler: nil)
+        }
+    }
+
+    // MARK: - returnCacheDataDontFetch
+
+    func testReturnCacheDataDontFetchCacheHit() throws {
+        let query = HeroNameQuery()
+
+        withCache(initialRecords: InitialCacheRecords.cacheHit) { (cache) in
+            let store = ApolloStore(cache: cache)
+
+            let client = ApolloClient(networkTransport: mockNetworkTransport, store: store)
+
+            let expectation = self.expectation(description: "Fetching query")
+
+            client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { (result, error) in
+                defer { expectation.fulfill() }
+
+                guard let result = result else { XCTFail("No query result");  return }
+
+                XCTAssertEqual(result.data?.hero?.name, "R2-D2")
+            }
+
+            self.waitForExpectations(timeout: 5, handler: nil)
+        }
+    }
+
+    func testReturnCacheDataDontFetch_emptyCache() throws {
+        try doTestReturnCacheDataDontFetchCacheMiss(with: InitialCacheRecords.emptyCache)
+    }
+
+    func testReturnCacheDataDontFetch_missingData() throws {
+        try doTestReturnCacheDataDontFetchCacheMiss(with: InitialCacheRecords.missingData)
+    }
+
+    func testReturnCacheDataDontFetch_queryRoot() throws {
+        try doTestReturnCacheDataDontFetchCacheMiss(with: InitialCacheRecords.queryRoot)
+    }
+
+    func doTestReturnCacheDataDontFetchCacheMiss(with initialRecords: RecordSet) throws {
+        let query = HeroNameQuery()
+
+        withCache(initialRecords: initialRecords) { (cache) in
+            let store = ApolloStore(cache: cache)
+
+            let client = ApolloClient(networkTransport: mockNetworkTransport, store: store)
+
+            let expectation = self.expectation(description: "Fetching query")
+
+            client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { (result, error) in
+                defer { expectation.fulfill() }
+
+                XCTAssertNil(error)
+                XCTAssertNil(result)
+            }
+
+            self.waitForExpectations(timeout: 5, handler: nil)
+        }
+    }
+}

--- a/StarWarsAPI/API.swift
+++ b/StarWarsAPI/API.swift
@@ -3512,7 +3512,7 @@ public final class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
 
 public final class HeroNameQuery: GraphQLQuery {
   public static let operationString =
-    "query HeroName($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n  }\n}"
+    "query HeroName($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    optionalString\n  }\n}"
 
   public var episode: Episode?
 
@@ -3556,6 +3556,7 @@ public final class HeroNameQuery: GraphQLQuery {
       public static let selections: [GraphQLSelection] = [
         GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
         GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        GraphQLField("optionalString", type: .scalar(String.self)),
       ]
 
       public var snapshot: Snapshot
@@ -3564,12 +3565,12 @@ public final class HeroNameQuery: GraphQLQuery {
         self.snapshot = snapshot
       }
 
-      public static func makeHuman(name: String) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name])
+      public static func makeHuman(name: String, optionalString: String? = nil) -> Hero {
+        return Hero(snapshot: ["__typename": "Human", "name": name, "optionalString": optionalString])
       }
 
-      public static func makeDroid(name: String) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name])
+      public static func makeDroid(name: String, optionalString: String? = nil) -> Hero {
+        return Hero(snapshot: ["__typename": "Droid", "name": name, "optionalString": optionalString])
       }
 
       public var __typename: String {
@@ -3588,6 +3589,16 @@ public final class HeroNameQuery: GraphQLQuery {
         }
         set {
           snapshot.updateValue(newValue, forKey: "name")
+        }
+      }
+
+      /// An optional string value
+      public var optionalString: String? {
+        get {
+          return snapshot["optionalString"] as? String
+        }
+        set {
+          snapshot.updateValue(newValue, forKey: "optionalString")
         }
       }
     }


### PR DESCRIPTION
Fixed regression from #177 (cache-misses resulting from prepopulating caches with an empty QUERY_ROOT). Added tests to verify query behavior against different cache-miss conditions. This work also fiixes #90.

*Issue #, if available:*
  - #90
  - #181 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
