### PR TITLE
Fix cacheKeyForObject handling for keys with dots (#110, #165)

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		FA0C12BF21CD360B00B438CB /* AWSAppSyncAuthType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0C12BE21CD360B00B438CB /* AWSAppSyncAuthType.swift */; };
 		FA0C12C121CD3BB200B438CB /* BasicAWSAPIKeyAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0C12C021CD3BB200B438CB /* BasicAWSAPIKeyAuthProvider.swift */; };
 		FA1A620C21E6533A00AA54D0 /* AWSAppSyncRetryHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1A620B21E6533A00AA54D0 /* AWSAppSyncRetryHandlerTests.swift */; };
+		FA2B4598221DDF2C00F68E6C /* CachePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2B4597221DDF2C00F68E6C /* CachePersistenceTests.swift */; };
 		FA38636E21DD8FF200DBA2BC /* MutationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA38636D21DD8FF200DBA2BC /* MutationQueueTests.swift */; };
 		FA3E128121D5259800F2D19A /* AWSAppSyncClientConfigurationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3E128021D5259800F2D19A /* AWSAppSyncClientConfigurationError.swift */; };
 		FA3E128321D5290900F2D19A /* AWSAppSyncClientInfoError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3E128221D5290900F2D19A /* AWSAppSyncClientInfoError.swift */; };
@@ -156,6 +157,8 @@
 		FABD706F2204E34600C99B47 /* AWSAppSyncCacheConfigurationMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABD706E2204E34600C99B47 /* AWSAppSyncCacheConfigurationMigration.swift */; };
 		FABD707122050EDF00C99B47 /* AWSAppSyncClientConfigurationTestsWithDatabaseURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABD707022050EDF00C99B47 /* AWSAppSyncClientConfigurationTestsWithDatabaseURL.swift */; };
 		FABD70752205101600C99B47 /* AWSAppSyncClientInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABD70742205101600C99B47 /* AWSAppSyncClientInfoTests.swift */; };
+		FAC28D3B221B0F09000F84CD /* CacheKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC28D3A221B0F09000F84CD /* CacheKeyTests.swift */; };
+		FAC28D3D221B1195000F84CD /* UnitTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC28D3C221B1195000F84CD /* UnitTestHelpers.swift */; };
 		FAC3E70C2208FB550037813E /* cacheConfigUnitTests-allTables.db in Resources */ = {isa = PBXBuildFile; fileRef = FAC3E70A2208F2190037813E /* cacheConfigUnitTests-allTables.db */; };
 		FAC3E70D2208FB550037813E /* cacheConfigUnitTests-noMutationRecords.db in Resources */ = {isa = PBXBuildFile; fileRef = FAC3E7082208F2190037813E /* cacheConfigUnitTests-noMutationRecords.db */; };
 		FAC3E70E2208FB550037813E /* cacheConfigUnitTests-noRecords.db in Resources */ = {isa = PBXBuildFile; fileRef = FAC3E7092208F2190037813E /* cacheConfigUnitTests-noRecords.db */; };
@@ -440,6 +443,7 @@
 		FA0C12C021CD3BB200B438CB /* BasicAWSAPIKeyAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicAWSAPIKeyAuthProvider.swift; sourceTree = "<group>"; };
 		FA0C12C721CD96BF00B438CB /* AWSAppSyncClientConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAppSyncClientConfigurationTests.swift; sourceTree = "<group>"; };
 		FA1A620B21E6533A00AA54D0 /* AWSAppSyncRetryHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAppSyncRetryHandlerTests.swift; sourceTree = "<group>"; };
+		FA2B4597221DDF2C00F68E6C /* CachePersistenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CachePersistenceTests.swift; sourceTree = "<group>"; };
 		FA30F363219B353800B92938 /* SubscriptionStressTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionStressTestHelper.swift; sourceTree = "<group>"; };
 		FA38636D21DD8FF200DBA2BC /* MutationQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationQueueTests.swift; sourceTree = "<group>"; };
 		FA3E128021D5259800F2D19A /* AWSAppSyncClientConfigurationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAppSyncClientConfigurationError.swift; sourceTree = "<group>"; };
@@ -476,6 +480,8 @@
 		FABD707022050EDF00C99B47 /* AWSAppSyncClientConfigurationTestsWithDatabaseURL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAppSyncClientConfigurationTestsWithDatabaseURL.swift; sourceTree = "<group>"; };
 		FABD707222050FD100C99B47 /* AWSAppSyncClientInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAppSyncClientInfo.swift; sourceTree = "<group>"; };
 		FABD70742205101600C99B47 /* AWSAppSyncClientInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAppSyncClientInfoTests.swift; sourceTree = "<group>"; };
+		FAC28D3A221B0F09000F84CD /* CacheKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheKeyTests.swift; sourceTree = "<group>"; };
+		FAC28D3C221B1195000F84CD /* UnitTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestHelpers.swift; sourceTree = "<group>"; };
 		FAC3E7072208F2190037813E /* cacheConfigUnitTests-noTables.db */ = {isa = PBXFileReference; lastKnownFileType = file; path = "cacheConfigUnitTests-noTables.db"; sourceTree = "<group>"; };
 		FAC3E7082208F2190037813E /* cacheConfigUnitTests-noMutationRecords.db */ = {isa = PBXFileReference; lastKnownFileType = file; path = "cacheConfigUnitTests-noMutationRecords.db"; sourceTree = "<group>"; };
 		FAC3E7092208F2190037813E /* cacheConfigUnitTests-noRecords.db */ = {isa = PBXFileReference; lastKnownFileType = file; path = "cacheConfigUnitTests-noRecords.db"; sourceTree = "<group>"; };
@@ -563,6 +569,7 @@
 			children = (
 				1700505E21543F94008B16B6 /* BatchedLoadTests.swift */,
 				1700505621543F94008B16B6 /* CacheKeyForFieldTests.swift */,
+				FA2B4597221DDF2C00F68E6C /* CachePersistenceTests.swift */,
 				1700505C21543F94008B16B6 /* DataLoaderTests.swift */,
 				17005076215445BD008B16B6 /* FetchQueryTests.swift */,
 				FA005A9F2216137C00BFBD13 /* FetchQueryTestsComplex.swift */,
@@ -840,6 +847,7 @@
 		FA8C62B221D6E3AA00FF9924 /* AWSAppSyncUnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				FAC28D3E221B119B000F84CD /* Helpers */,
 				CCEF79DA21DE7CA6004AD64D /* AppSyncApolloCustomizationTests.swift */,
 				FAEC08E021CBE8B900A816DE /* AppSyncClientComplexObjectMutationUnitTests.swift */,
 				FAC3E711220900A20037813E /* AWSAppSyncCacheConfigurationMigrationTests.swift */,
@@ -849,6 +857,7 @@
 				FABD70742205101600C99B47 /* AWSAppSyncClientInfoTests.swift */,
 				FA1A620B21E6533A00AA54D0 /* AWSAppSyncRetryHandlerTests.swift */,
 				FAF5D78A21D3EFA600FC04D2 /* AWSAppSyncServiceConfigTests.swift */,
+				FAC28D3A221B0F09000F84CD /* CacheKeyTests.swift */,
 				FAE1E0EE21D3DC9A005767C7 /* Foundation+UtilsTests.swift */,
 				FA8C62B521D6E3AA00FF9924 /* Info.plist */,
 				FA005959221222D800BFBD13 /* MutationOptimisticUpdateTests.swift */,
@@ -897,6 +906,14 @@
 				FA8C62AB21D6E22400FF9924 /* S3ObjectWrapper.swift */,
 			);
 			path = AWSAppSyncTestCommon;
+			sourceTree = "<group>";
+		};
+		FAC28D3E221B119B000F84CD /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				FAC28D3C221B1195000F84CD /* UnitTestHelpers.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		FAFD409121D702EA0063D894 /* Helpers */ = {
@@ -1443,6 +1460,7 @@
 			files = (
 				1700506E21544011008B16B6 /* TestCacheProvider.swift in Sources */,
 				1700506821543F94008B16B6 /* MutatingResultsTests.swift in Sources */,
+				FA2B4598221DDF2C00F68E6C /* CachePersistenceTests.swift in Sources */,
 				1700507C215445BE008B16B6 /* WatchQueryTests.swift in Sources */,
 				1700506121543F94008B16B6 /* CacheKeyForFieldTests.swift in Sources */,
 				1700507A215445BE008B16B6 /* FetchQueryTests.swift in Sources */,
@@ -1580,6 +1598,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FAFB258922051D9600068B38 /* AWSAppSyncCacheConfigurationTests.swift in Sources */,
+				FAC28D3D221B1195000F84CD /* UnitTestHelpers.swift in Sources */,
 				FAFD409221D7039C0063D894 /* SubscriptionMessagesQueueTests.swift in Sources */,
 				CCEF79DB21DE7CA6004AD64D /* AppSyncApolloCustomizationTests.swift in Sources */,
 				FA88834721E3D05800DEBCB3 /* ReachabilityChangeNotifierTests.swift in Sources */,
@@ -1593,6 +1612,7 @@
 				FA38636E21DD8FF200DBA2BC /* MutationQueueTests.swift in Sources */,
 				FA4F0D9821D6EDA50099D165 /* SyncStrategyTests.swift in Sources */,
 				FA4F0D9721D6EDA20099D165 /* AWSAppSyncServiceConfigTests.swift in Sources */,
+				FAC28D3B221B0F09000F84CD /* CacheKeyTests.swift in Sources */,
 				FA4F0D9521D6ED9E0099D165 /* AppSyncClientComplexObjectMutationUnitTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AWSAppSyncUnitTests/CacheKeyTests.swift
+++ b/AWSAppSyncUnitTests/CacheKeyTests.swift
@@ -1,0 +1,105 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Amazon Software License
+// http://aws.amazon.com/asl/
+//
+
+import XCTest
+@testable import AWSAppSync
+@testable import AWSAppSyncTestCommon
+
+/// The AppSync client decomposes nested objects according to their path components, and joins them into a composite
+/// key joined by a dot (`"."`). In the past, this has caused issues with keys that natively contain ".", such as
+/// floating-point numbers or email addresses (#110, #165).
+class CacheKeyTests: XCTestCase {
+    static let fetchQueue = DispatchQueue(label: "CacheKeyTests.fetch")
+    static let mutationQueue = DispatchQueue(label: "CacheKeyTests.mutations")
+
+    var cacheConfiguration: AWSAppSyncCacheConfiguration!
+    let mockHTTPTransport = MockAWSNetworkTransport()
+
+    // Set up a new DB for each test
+    override func setUp() {
+        let tempDir = FileManager.default.temporaryDirectory
+        let rootDirectory = tempDir.appendingPathComponent("CacheKeyTests-\(UUID().uuidString)")
+        cacheConfiguration = try! AWSAppSyncCacheConfiguration(withRootDirectory: rootDirectory)
+    }
+
+    override func tearDown() {
+        MockReachabilityProvidingFactory.clearShared()
+        NetworkReachabilityNotifier.clearShared()
+    }
+
+    func testCacheKeyForObject_withKeyOfType_stringWithoutDots_withBackingDatabase() throws {
+        let postId = "part1-part2"
+        try doCacheKeyTest(with: postId, usingBackingDatabase: true)
+    }
+
+    func testCacheKeyForObject_withKeyOfType_emailAddress_withBackingDatabase() throws {
+        let postId = "test.email@amazon.com"
+        try doCacheKeyTest(with: postId, usingBackingDatabase: true)
+    }
+
+    func testCacheKeyForObject_withKeyOfType_stringWithoutDots_withoutBackingDatabase() throws {
+        let postId = "TEMP-\(UUID().uuidString)"
+        try doCacheKeyTest(with: postId, usingBackingDatabase: false)
+    }
+
+    func testCacheKeyForObject_withKeyOfType_emailAddress_withoutBackingDatabase() throws {
+        let postId = "test.email@amazon.com"
+        try doCacheKeyTest(with: postId, usingBackingDatabase: false)
+    }
+
+    // MARK: - Utilities
+
+    /// Tests that a record retrieved from the service is retrievable from the cache using the same ID.
+    ///
+    /// Test methodology:
+    /// 1. Query only the service to ensure we populate the cache via the AppSync/Apollo update mechanism
+    /// 2. Query only the cache to ensure we get the expected result
+    func doCacheKeyTest(with postId: GraphQLID, usingBackingDatabase: Bool) throws {
+
+        let result = UnitTestHelpers.makeGetPostResponseBody(with: postId)
+
+        let mockHTTPTransport = MockAWSNetworkTransport()
+        mockHTTPTransport.sendOperationHandlerResponseBody = result
+
+        let resolvedCacheConfiguration = usingBackingDatabase ? cacheConfiguration : nil
+
+        // Default cacheKeyForObject is set to extract `id`
+        let appSyncClient = try UnitTestHelpers.makeAppSyncClient(using: mockHTTPTransport,
+                                                                  cacheConfiguration: resolvedCacheConfiguration)
+
+        let fetchFromServiceComplete = expectation(description: "Fetch from service complete")
+        appSyncClient.fetch(query: GetPostQuery(id: postId),
+                            cachePolicy: .fetchIgnoringCacheData,
+                            queue: CacheKeyTests.fetchQueue) { _, _ in
+                                fetchFromServiceComplete.fulfill()
+        }
+
+        wait(for: [fetchFromServiceComplete], timeout: 1.0)
+
+        let fetchFromCacheComplete = expectation(description: "Query from cache is complete")
+        appSyncClient.fetch(query: GetPostQuery(id: postId),
+                            cachePolicy: .returnCacheDataDontFetch,
+                            queue: CacheKeyTests.fetchQueue) { result, error in
+                                defer {
+                                    fetchFromCacheComplete.fulfill()
+                                }
+
+                                guard error == nil else {
+                                    XCTFail("Error fetching from cache: \(String(describing: error))")
+                                    return
+                                }
+
+                                guard let result = result else {
+                                    XCTFail("Result unexpectedly nil fetching postId \(postId) from cache")
+                                    return
+                                }
+
+                                XCTAssertEqual(result.data?.getPost?.id, postId)
+        }
+
+        wait(for: [fetchFromCacheComplete], timeout: 1.0)
+    }
+}

--- a/AWSAppSyncUnitTests/Helpers/UnitTestHelpers.swift
+++ b/AWSAppSyncUnitTests/Helpers/UnitTestHelpers.swift
@@ -1,0 +1,87 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Amazon Software License
+// http://aws.amazon.com/asl/
+//
+
+import Foundation
+
+@testable import AWSAppSync
+@testable import AWSAppSyncTestCommon
+
+struct UnitTestHelpers {
+
+    static func makeAppSyncClient(using httpTransport: AWSNetworkTransport,
+                                  cacheConfiguration: AWSAppSyncCacheConfiguration?) throws -> DeinitNotifiableAppSyncClient {
+        let helper = try AppSyncClientTestHelper(
+            with: .apiKey,
+            testConfiguration: AppSyncClientTestConfiguration.forUnitTests,
+            cacheConfiguration: cacheConfiguration,
+            httpTransport: httpTransport,
+            reachabilityFactory: MockReachabilityProvidingFactory.self
+        )
+
+        if let cacheConfiguration = cacheConfiguration {
+            print("AppSyncClient created with cacheConfiguration: \(cacheConfiguration)")
+        } else {
+            print("AppSyncClient created with in-memory caches")
+        }
+        return helper.appSyncClient
+    }
+
+    static func makeAddPostResponseBody(withId id: GraphQLID,
+                                        for mutation: CreatePostWithoutFileUsingParametersMutation) -> JSONObject {
+        let createdDateMilliseconds = Date().timeIntervalSince1970 * 1000
+
+        let response = CreatePostWithoutFileUsingParametersMutation.Data.CreatePostWithoutFileUsingParameter(
+            id: id,
+            author: mutation.author,
+            title: mutation.title,
+            content: mutation.content,
+            url: mutation.url,
+            ups: mutation.ups ?? 0,
+            downs: mutation.downs ?? 0,
+            file: nil,
+            createdDate: String(describing: Int(createdDateMilliseconds)),
+            awsDs: nil)
+        return ["data": ["createPostWithoutFileUsingParameters": response.jsonObject]]
+    }
+
+    static func makeGetPostResponseBody(with id: GraphQLID) -> JSONObject {
+        let createdDateMilliseconds = Date().timeIntervalSince1970 * 1000
+        let post = GetPostQuery.Data.GetPost(id: id,
+                                             author: DefaultTestPostData.author,
+                                             title: DefaultTestPostData.title,
+                                             content: DefaultTestPostData.content,
+                                             url: DefaultTestPostData.url,
+                                             ups: DefaultTestPostData.ups,
+                                             downs: DefaultTestPostData.downs,
+                                             file: nil,
+                                             createdDate: String(describing: Int(createdDateMilliseconds)),
+                                             awsDs: nil)
+
+        let response = GetPostQuery.Data(getPost: post)
+        return [
+            "data": response.jsonObject
+        ]
+    }
+
+    static func makeListPostsResponseBody(withId id: GraphQLID) -> JSONObject {
+        let createdDateMilliseconds = Date().timeIntervalSince1970 * 1000
+        let post = ListPostsQuery.Data.ListPost(id: id,
+                                                author: "Test author",
+                                                title: "Test Post",
+                                                content: "Test Content",
+                                                url: "http://test.com",
+                                                ups: 0,
+                                                downs: 0,
+                                                file: nil,
+                                                createdDate: String(describing: Int(createdDateMilliseconds)),
+                                                awsDs: nil)
+        let response = ListPostsQuery.Data(listPosts: [post])
+        return [
+            "data": response.jsonObject
+        ]
+    }
+
+}

--- a/AWSAppSyncUnitTests/MutationOptimisticUpdateTests.swift
+++ b/AWSAppSyncUnitTests/MutationOptimisticUpdateTests.swift
@@ -21,13 +21,14 @@ class MutationOptimisticUpdateTests: XCTestCase {
     static let fetchQueue = DispatchQueue(label: "MutationOptimisticUpdateTests.fetch")
     static let mutationQueue = DispatchQueue(label: "MutationOptimisticUpdateTests.mutations")
 
-    var cacheConfigRootDirectory: URL!
+    var cacheConfiguration: AWSAppSyncCacheConfiguration!
     let mockHTTPTransport = MockAWSNetworkTransport()
 
     // Set up a new DB for each test
     override func setUp() {
         let tempDir = FileManager.default.temporaryDirectory
-        cacheConfigRootDirectory = tempDir.appendingPathComponent("MutationOptimisticUpdateTests-\(UUID().uuidString)")
+        let rootDirectory = tempDir.appendingPathComponent("MutationOptimisticUpdateTests-\(UUID().uuidString)")
+        cacheConfiguration = try! AWSAppSyncCacheConfiguration(withRootDirectory: rootDirectory)
     }
 
     override func tearDown() {
@@ -57,7 +58,7 @@ class MutationOptimisticUpdateTests: XCTestCase {
 
         mockHTTPTransport.sendOperationResponseQueue.append(nonDispatchingResponseBlock)
 
-        let appSyncClient = try makeAppSyncClient(using: mockHTTPTransport)
+        let appSyncClient = try UnitTestHelpers.makeAppSyncClient(using: mockHTTPTransport, cacheConfiguration: nil)
 
         appSyncClient.perform(mutation: addPost, queue: MutationOptimisticUpdateTests.mutationQueue)
 
@@ -94,7 +95,7 @@ class MutationOptimisticUpdateTests: XCTestCase {
 
         // First response should be a query response from the "server" that will populate the local cache.
         let idFromServer = "FROM-SERVER-\(UUID().uuidString)"
-        let serverResponse = makeListPostsResponseBody(withId: idFromServer)
+        let serverResponse = UnitTestHelpers.makeListPostsResponseBody(withId: idFromServer)
         mockHTTPTransport.sendOperationResponseQueue.append(serverResponse)
 
         // We will set up a response block that never actually invokes the completion handler. This allows us to
@@ -108,7 +109,7 @@ class MutationOptimisticUpdateTests: XCTestCase {
 
         mockHTTPTransport.sendOperationResponseQueue.append(nonDispatchingResponseBlock)
 
-        let appSyncClient = try makeAppSyncClient(using: mockHTTPTransport)
+        let appSyncClient = try UnitTestHelpers.makeAppSyncClient(using: mockHTTPTransport, cacheConfiguration: nil)
 
         let initialQueryPerformed = expectation(description: "Initial listPosts query performed")
         // Note that we specify a `.fetchIgnoringCacheData` policy to ensure we only get our mocked response,
@@ -216,7 +217,11 @@ class MutationOptimisticUpdateTests: XCTestCase {
 
         mockHTTPTransport.sendOperationResponseQueue.append(nonDispatchingResponseBlock)
 
-        let appSyncClient = try makeAppSyncClient(using: mockHTTPTransport, withBackingDatabase: usingBackingDatabase)
+        let resolvedCacheConfiguration: AWSAppSyncCacheConfiguration? = usingBackingDatabase
+            ? cacheConfiguration
+            : nil
+
+        let appSyncClient = try UnitTestHelpers.makeAppSyncClient(using: mockHTTPTransport, cacheConfiguration: resolvedCacheConfiguration)
 
         let newPost = ListPostsQuery.Data.ListPost(
             id: "TEMPORARY-\(UUID().uuidString)",
@@ -247,6 +252,12 @@ class MutationOptimisticUpdateTests: XCTestCase {
                     XCTFail("Unexpected error performing optimistic update: \(error)")
                 }
         })
+
+        wait(
+            for: [
+                optimisticUpdatePerformed
+            ],
+            timeout: 1.0)
 
         let cacheHasOptimisticUpdateResult = expectation(description: "Cache returns optimistic update result")
 
@@ -280,65 +291,9 @@ class MutationOptimisticUpdateTests: XCTestCase {
         wait(
             for: [
                 nonDispatchingResponseBlockInvoked,
-                optimisticUpdatePerformed,
                 cacheHasOptimisticUpdateResult
             ],
             timeout: 1.0)
-    }
-
-    func makeAddPostResponseBody(withId id: GraphQLID,
-                                 forMutation mutation: CreatePostWithoutFileUsingParametersMutation) -> JSONObject {
-        let createdDateMilliseconds = Date().timeIntervalSince1970 * 1000
-
-        let response = CreatePostWithoutFileUsingParametersMutation.Data.CreatePostWithoutFileUsingParameter(
-            id: id,
-            author: mutation.author,
-            title: mutation.title,
-            content: mutation.content,
-            url: mutation.url,
-            ups: mutation.ups ?? 0,
-            downs: mutation.downs ?? 0,
-            file: nil,
-            createdDate: String(describing: Int(createdDateMilliseconds)),
-            awsDs: nil)
-        return ["data": ["createPostWithoutFileUsingParameters": response.jsonObject]]
-    }
-
-    func makeListPostsResponseBody(withId id: GraphQLID) -> JSONObject {
-        let createdDateMilliseconds = Date().timeIntervalSince1970 * 1000
-        let post = ListPostsQuery.Data.ListPost(id: id,
-                                                author: "Test author",
-                                                title: "Test Post",
-                                                content: "Test Content",
-                                                url: "http://test.com",
-                                                ups: 0,
-                                                downs: 0,
-                                                file: nil,
-                                                createdDate: String(describing: Int(createdDateMilliseconds)),
-                                                awsDs: nil)
-        let response = ListPostsQuery.Data(listPosts: [post])
-        return [
-            "data": response.jsonObject
-        ]
-    }
-
-    func makeAppSyncClient(using httpTransport: AWSNetworkTransport,
-                           withBackingDatabase useBackingDatabase: Bool = true) throws -> DeinitNotifiableAppSyncClient {
-        let cacheConfiguration: AWSAppSyncCacheConfiguration? = useBackingDatabase ? try AWSAppSyncCacheConfiguration(withRootDirectory: cacheConfigRootDirectory) : nil
-        let helper = try AppSyncClientTestHelper(
-            with: .apiKey,
-            testConfiguration: AppSyncClientTestConfiguration.forUnitTests,
-            cacheConfiguration: cacheConfiguration,
-            httpTransport: httpTransport,
-            reachabilityFactory: MockReachabilityProvidingFactory.self
-        )
-
-        if let cacheConfiguration = cacheConfiguration {
-            print("AppSyncClient created with cacheConfiguration: \(cacheConfiguration)")
-        } else {
-            print("AppSyncClient created with in-memory caches")
-        }
-        return helper.appSyncClient
     }
 
 }

--- a/ApolloTests/CachePersistenceTests.swift
+++ b/ApolloTests/CachePersistenceTests.swift
@@ -1,0 +1,172 @@
+import XCTest
+
+@testable import AWSAppSync
+import StarWarsAPI
+
+class CachePersistenceTests: XCTestCase {
+    @available(iOS 10.0, *)
+    func testHumanQueryWithDotInFieldArgumentFromCache() {
+        let directoryURL = FileManager
+            .default
+            .temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+
+        try! FileManager.default.createDirectory(at: directoryURL,
+                                                 withIntermediateDirectories: true,
+                                                 attributes: nil)
+
+        let fileURL = directoryURL.appendingPathComponent("queries.db")
+
+        print("Testing with cache DB at:\n\(fileURL.path)")
+
+        SQLiteTestCacheProvider.withCache(fileURL: fileURL) { cache in
+            let networkTransport = MockNetworkTransport(body: [
+                "data": [
+                    "human": [
+                        "__typename": "Human",
+                        "name": "Test person 1",
+                        "mass": 90,
+                        "friendsFilteredById": [
+                            [
+                                "__typename": "Human",
+                                "id": "100.2",
+                                "name": "Test person 2",
+                            ]
+                        ]
+                    ]
+                ]
+                ])
+
+            let store = ApolloStore(cache: cache)
+            let client = ApolloClient(networkTransport: networkTransport, store: store)
+
+            let query = HumanFriendsFilteredByIdQuery(id: "100.1", friendId: "100.2")
+            // populate cache by fetching from server
+            let fetchFromServer = self.expectation(description: "Fetching query from server")
+            client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { (result, error) in
+                defer { fetchFromServer.fulfill() }
+
+                guard let result = result else { XCTFail("No query result");  return }
+
+                XCTAssertEqual(result.data?.human?.name, "Test person 1")
+                XCTAssertEqual(result.data?.human?.friendsFilteredById?[0]?.id, "100.2")
+                XCTAssertEqual(result.data?.human?.friendsFilteredById?[0]?.name, "Test person 2")
+            }
+
+            self.wait(for: [fetchFromServer], timeout: 5.0)
+
+            // read from cache
+            let fetchFromCache = self.expectation(description: "Fetching query from cache")
+            client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { (result, error) in
+                defer { fetchFromCache.fulfill() }
+
+                guard let result = result else { XCTFail("No query result");  return }
+
+                XCTAssertEqual(result.data?.human?.name, "Test person 1")
+                XCTAssertEqual(result.data?.human?.friendsFilteredById?[0]?.id, "100.2")
+                XCTAssertEqual(result.data?.human?.friendsFilteredById?[0]?.name, "Test person 2")
+            }
+
+            self.wait(for: [fetchFromCache], timeout: 5.0)
+        }
+    }
+
+    @available(iOS 10.0, *)
+    func testHumanQueryWithDotInIdFromCache() {
+        let directoryURL = FileManager
+            .default
+            .temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+
+        try! FileManager.default.createDirectory(at: directoryURL,
+                                            withIntermediateDirectories: true,
+                                            attributes: nil)
+
+        let fileURL = directoryURL.appendingPathComponent("queries.db")
+
+        print("Testing with cache DB at:\n\(fileURL.path)")
+
+        SQLiteTestCacheProvider.withCache(fileURL: fileURL) { cache in
+            let networkTransport = MockNetworkTransport(body: [
+                "data": [
+                    "human": [
+                        "name": "Test person",
+                        "__typename": "Human",
+                        "mass": 90
+                    ]
+                ]
+                ])
+
+            let store = ApolloStore(cache: cache)
+            let client = ApolloClient(networkTransport: networkTransport, store: store)
+
+            let query = HumanQuery(id: "100.1")
+
+            // populate cache by fetching from server
+            let fetchFromServer = self.expectation(description: "Fetching query from server")
+            client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { (result, error) in
+                defer { fetchFromServer.fulfill() }
+
+                guard let result = result else { XCTFail("No query result");  return }
+
+                XCTAssertEqual(result.data?.human?.name, "Test person")
+            }
+
+            self.wait(for: [fetchFromServer], timeout: 5.0)
+
+            // read from cache
+            let fetchFromCache = self.expectation(description: "Fetching query from cache")
+            client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { (result, error) in
+                defer { fetchFromCache.fulfill() }
+
+                guard let result = result else { XCTFail("No query result");  return }
+
+                XCTAssertEqual(result.data?.human?.name, "Test person")
+            }
+
+            self.wait(for: [fetchFromCache], timeout: 5.0)
+        }
+    }
+
+    func testFetchAndPersist() {
+        let query = HeroNameQuery()
+        let sqliteFileURL = SQLiteTestCacheProvider.temporarySQLiteFileURL()
+
+        SQLiteTestCacheProvider.withCache(fileURL: sqliteFileURL) { (cache) in
+            let store = ApolloStore(cache: cache)
+            let networkTransport = MockNetworkTransport(body: [
+                "data": [
+                    "hero": [
+                        "name": "Luke Skywalker",
+                        "__typename": "Human"
+                    ]
+                ]
+                ])
+            let client = ApolloClient(networkTransport: networkTransport, store: store)
+
+            let networkExpectation = self.expectation(description: "Fetching query from network")
+            let newCacheExpectation = self.expectation(description: "Fetch query from new cache")
+
+            client.fetch(query: query, cachePolicy: .fetchIgnoringCacheData) { (result, error) in
+                defer { networkExpectation.fulfill() }
+                guard let result = result else { XCTFail("No query result");  return }
+                XCTAssertEqual(result.data?.hero?.name, "Luke Skywalker")
+
+                // Do another fetch from cache to ensure that data is cached before creating new cache
+                client.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { (result, error) in
+                    SQLiteTestCacheProvider.withCache(fileURL: sqliteFileURL) { (cache) in
+                        let newStore = ApolloStore(cache: cache)
+                        let newClient = ApolloClient(networkTransport: networkTransport, store: newStore)
+                        newClient.fetch(query: query, cachePolicy: .returnCacheDataDontFetch) { (result, error) in
+                            defer { newCacheExpectation.fulfill() }
+                            guard let result = result else { XCTFail("No query result");  return }
+                            XCTAssertEqual(result.data?.hero?.name, "Luke Skywalker")
+                            _ = newClient // Workaround for a bug - ensure that newClient is retained until this block is run
+                        }
+                    }
+                }
+            }
+            self.waitForExpectations(timeout: 2, handler: nil)
+        }
+    }
+}

--- a/ApolloTests/TestCacheProvider.swift
+++ b/ApolloTests/TestCacheProvider.swift
@@ -35,3 +35,31 @@ extension XCTestCase {
     return try type(of: self).cacheProviderClass.withCache(initialRecords: initialRecords, execute: test)
   }
 }
+
+public class SQLiteTestCacheProvider: TestCacheProvider {
+    public static func withCache(initialRecords: RecordSet? = nil, execute test: (NormalizedCache) throws -> ()) rethrows {
+        return try withCache(initialRecords: initialRecords, fileURL: nil, execute: test)
+    }
+
+    /// Execute a test block rather than return a cache synchronously, since cache setup may be
+    /// asynchronous at some point.
+    public static func withCache(initialRecords: RecordSet? = nil, fileURL: URL? = nil, execute test: (NormalizedCache) throws -> ()) rethrows {
+        let fileURL = fileURL ?? temporarySQLiteFileURL()
+        let cache = try! AWSSQLiteNormalizedCache(fileURL: fileURL)
+        if let initialRecords = initialRecords {
+            _ = cache.merge(records: initialRecords) // This is synchronous
+        }
+        try test(cache)
+    }
+
+    public static func temporarySQLiteFileURL() -> URL {
+        let applicationSupportPath = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!
+        let applicationSupportURL = URL(fileURLWithPath: applicationSupportPath)
+        let temporaryDirectoryURL = try! FileManager.default.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: applicationSupportURL,
+            create: true)
+        return temporaryDirectoryURL.appendingPathComponent("db.sqlite3")
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The AWS AppSync SDK for iOS enables you to access your AWS AppSync backend and perform operations like `Queries`, `Mutations` and `Subscriptions`. The SDK also includes support for offline operations.
 
+## 2.10.2
+
+### Bug fixes
+
+- Fix a bug where queries with dots (`"."`) in the arguments were not being properly cached ([Issue #110](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/110), [#165](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/165))
+
 ## 2.10.1
 
 ### Bug fixes

--- a/StarWarsAPI/API.swift
+++ b/StarWarsAPI/API.swift
@@ -4,6563 +4,6719 @@ import AWSAppSync
 
 /// The episodes in the Star Wars trilogy
 public enum Episode: RawRepresentable, Equatable, JSONDecodable, JSONEncodable {
-  public typealias RawValue = String
-  /// Star Wars Episode IV: A New Hope, released in 1977.
-  case newhope
-  /// Star Wars Episode V: The Empire Strikes Back, released in 1980.
-  case empire
-  /// Star Wars Episode VI: Return of the Jedi, released in 1983.
-  case jedi
-  /// Auto generated constant for unknown enum values
-  case unknown(RawValue)
+    public typealias RawValue = String
+    /// Star Wars Episode IV: A New Hope, released in 1977.
+    case newhope
+    /// Star Wars Episode V: The Empire Strikes Back, released in 1980.
+    case empire
+    /// Star Wars Episode VI: Return of the Jedi, released in 1983.
+    case jedi
+    /// Auto generated constant for unknown enum values
+    case unknown(RawValue)
 
-  public init?(rawValue: RawValue) {
-    switch rawValue {
-      case "NEWHOPE": self = .newhope
-      case "EMPIRE": self = .empire
-      case "JEDI": self = .jedi
-      default: self = .unknown(rawValue)
+    public init?(rawValue: RawValue) {
+        switch rawValue {
+        case "NEWHOPE": self = .newhope
+        case "EMPIRE": self = .empire
+        case "JEDI": self = .jedi
+        default: self = .unknown(rawValue)
+        }
     }
-  }
 
-  public var rawValue: RawValue {
-    switch self {
-      case .newhope: return "NEWHOPE"
-      case .empire: return "EMPIRE"
-      case .jedi: return "JEDI"
-      case .unknown(let value): return value
+    public var rawValue: RawValue {
+        switch self {
+        case .newhope: return "NEWHOPE"
+        case .empire: return "EMPIRE"
+        case .jedi: return "JEDI"
+        case .unknown(let value): return value
+        }
     }
-  }
 
-  public static func == (lhs: Episode, rhs: Episode) -> Bool {
-    switch (lhs, rhs) {
-      case (.newhope, .newhope): return true
-      case (.empire, .empire): return true
-      case (.jedi, .jedi): return true
-      case (.unknown(let lhsValue), .unknown(let rhsValue)): return lhsValue == rhsValue
-      default: return false
+    public static func == (lhs: Episode, rhs: Episode) -> Bool {
+        switch (lhs, rhs) {
+        case (.newhope, .newhope): return true
+        case (.empire, .empire): return true
+        case (.jedi, .jedi): return true
+        case (.unknown(let lhsValue), .unknown(let rhsValue)): return lhsValue == rhsValue
+        default: return false
+        }
     }
-  }
 }
 
 /// The input object sent when someone is creating a new review
 public struct ReviewInput: GraphQLMapConvertible {
-  public var graphQLMap: GraphQLMap
+    public var graphQLMap: GraphQLMap
 
-  public init(stars: Int, commentary: Optional<String?> = nil, favoriteColor: Optional<ColorInput?> = nil) {
-    graphQLMap = ["stars": stars, "commentary": commentary, "favorite_color": favoriteColor]
-  }
+    public init(stars: Int, commentary: Optional<String?> = nil, favoriteColor: Optional<ColorInput?> = nil) {
+        graphQLMap = ["stars": stars, "commentary": commentary, "favorite_color": favoriteColor]
+    }
 
-  /// 0-5 stars
-  public var stars: Int {
-    get {
-      return graphQLMap["stars"] as! Int
+    /// 0-5 stars
+    public var stars: Int {
+        get {
+            return graphQLMap["stars"] as! Int
+        }
+        set {
+            graphQLMap.updateValue(newValue, forKey: "stars")
+        }
     }
-    set {
-      graphQLMap.updateValue(newValue, forKey: "stars")
-    }
-  }
 
-  /// Comment about the movie, optional
-  public var commentary: Optional<String?> {
-    get {
-      return graphQLMap["commentary"] as! Optional<String?>
+    /// Comment about the movie, optional
+    public var commentary: Optional<String?> {
+        get {
+            return graphQLMap["commentary"] as! Optional<String?>
+        }
+        set {
+            graphQLMap.updateValue(newValue, forKey: "commentary")
+        }
     }
-    set {
-      graphQLMap.updateValue(newValue, forKey: "commentary")
-    }
-  }
 
-  /// Favorite color, optional
-  public var favoriteColor: Optional<ColorInput?> {
-    get {
-      return graphQLMap["favoriteColor"] as! Optional<ColorInput?>
+    /// Favorite color, optional
+    public var favoriteColor: Optional<ColorInput?> {
+        get {
+            return graphQLMap["favoriteColor"] as! Optional<ColorInput?>
+        }
+        set {
+            graphQLMap.updateValue(newValue, forKey: "favoriteColor")
+        }
     }
-    set {
-      graphQLMap.updateValue(newValue, forKey: "favoriteColor")
-    }
-  }
 }
 
 /// The input object sent when passing in a color
 public struct ColorInput: GraphQLMapConvertible {
-  public var graphQLMap: GraphQLMap
+    public var graphQLMap: GraphQLMap
 
-  public init(red: Int, green: Int, blue: Int) {
-    graphQLMap = ["red": red, "green": green, "blue": blue]
-  }
+    public init(red: Int, green: Int, blue: Int) {
+        graphQLMap = ["red": red, "green": green, "blue": blue]
+    }
 
-  public var red: Int {
-    get {
-      return graphQLMap["red"] as! Int
+    public var red: Int {
+        get {
+            return graphQLMap["red"] as! Int
+        }
+        set {
+            graphQLMap.updateValue(newValue, forKey: "red")
+        }
     }
-    set {
-      graphQLMap.updateValue(newValue, forKey: "red")
-    }
-  }
 
-  public var green: Int {
-    get {
-      return graphQLMap["green"] as! Int
+    public var green: Int {
+        get {
+            return graphQLMap["green"] as! Int
+        }
+        set {
+            graphQLMap.updateValue(newValue, forKey: "green")
+        }
     }
-    set {
-      graphQLMap.updateValue(newValue, forKey: "green")
-    }
-  }
 
-  public var blue: Int {
-    get {
-      return graphQLMap["blue"] as! Int
+    public var blue: Int {
+        get {
+            return graphQLMap["blue"] as! Int
+        }
+        set {
+            graphQLMap.updateValue(newValue, forKey: "blue")
+        }
     }
-    set {
-      graphQLMap.updateValue(newValue, forKey: "blue")
-    }
-  }
 }
 
 public final class CreateReviewForEpisodeMutation: GraphQLMutation {
-  public static let operationString =
+    public static let operationString =
     "mutation CreateReviewForEpisode($episode: Episode!, $review: ReviewInput!) {\n  createReview(episode: $episode, review: $review) {\n    __typename\n    stars\n    commentary\n  }\n}"
 
-  public var episode: Episode
-  public var review: ReviewInput
+    public var episode: Episode
+    public var review: ReviewInput
 
-  public init(episode: Episode, review: ReviewInput) {
-    self.episode = episode
-    self.review = review
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode, "review": review]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Mutation"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("createReview", arguments: ["episode": GraphQLVariable("episode"), "review": GraphQLVariable("review")], type: .object(CreateReview.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode, review: ReviewInput) {
+        self.episode = episode
+        self.review = review
     }
 
-    public init(createReview: CreateReview? = nil) {
-      self.init(snapshot: ["__typename": "Mutation", "createReview": createReview.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode, "review": review]
     }
 
-    public var createReview: CreateReview? {
-      get {
-        return (snapshot["createReview"] as? Snapshot).flatMap { CreateReview(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "createReview")
-      }
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Mutation"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("createReview", arguments: ["episode": GraphQLVariable("episode"), "review": GraphQLVariable("review")], type: .object(CreateReview.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(createReview: CreateReview? = nil) {
+            self.init(snapshot: ["__typename": "Mutation", "createReview": createReview.flatMap { $0.snapshot }])
+        }
+
+        public var createReview: CreateReview? {
+            get {
+                return (snapshot["createReview"] as? Snapshot).flatMap { CreateReview(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "createReview")
+            }
+        }
+
+        public struct CreateReview: GraphQLSelectionSet {
+            public static let possibleTypes = ["Review"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("stars", type: .nonNull(.scalar(Int.self))),
+                GraphQLField("commentary", type: .scalar(String.self)),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public init(stars: Int, commentary: String? = nil) {
+                self.init(snapshot: ["__typename": "Review", "stars": stars, "commentary": commentary])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The number of stars this review gave, 1-5
+            public var stars: Int {
+                get {
+                    return snapshot["stars"]! as! Int
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "stars")
+                }
+            }
+
+            /// Comment about the movie
+            public var commentary: String? {
+                get {
+                    return snapshot["commentary"] as? String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "commentary")
+                }
+            }
+        }
     }
-
-    public struct CreateReview: GraphQLSelectionSet {
-      public static let possibleTypes = ["Review"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("stars", type: .nonNull(.scalar(Int.self))),
-        GraphQLField("commentary", type: .scalar(String.self)),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public init(stars: Int, commentary: String? = nil) {
-        self.init(snapshot: ["__typename": "Review", "stars": stars, "commentary": commentary])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The number of stars this review gave, 1-5
-      public var stars: Int {
-        get {
-          return snapshot["stars"]! as! Int
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "stars")
-        }
-      }
-
-      /// Comment about the movie
-      public var commentary: String? {
-        get {
-          return snapshot["commentary"] as? String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "commentary")
-        }
-      }
-    }
-  }
 }
 
 public final class CreateAwesomeReviewMutation: GraphQLMutation {
-  public static let operationString =
+    public static let operationString =
     "mutation CreateAwesomeReview {\n  createReview(episode: JEDI, review: {stars: 10, commentary: \"This is awesome!\"}) {\n    __typename\n    stars\n    commentary\n  }\n}"
 
-  public init() {
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Mutation"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("createReview", arguments: ["episode": "JEDI", "review": ["stars": 10, "commentary": "This is awesome!"]], type: .object(CreateReview.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init() {
     }
 
-    public init(createReview: CreateReview? = nil) {
-      self.init(snapshot: ["__typename": "Mutation", "createReview": createReview.flatMap { $0.snapshot }])
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Mutation"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("createReview", arguments: ["episode": "JEDI", "review": ["stars": 10, "commentary": "This is awesome!"]], type: .object(CreateReview.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(createReview: CreateReview? = nil) {
+            self.init(snapshot: ["__typename": "Mutation", "createReview": createReview.flatMap { $0.snapshot }])
+        }
+
+        public var createReview: CreateReview? {
+            get {
+                return (snapshot["createReview"] as? Snapshot).flatMap { CreateReview(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "createReview")
+            }
+        }
+
+        public struct CreateReview: GraphQLSelectionSet {
+            public static let possibleTypes = ["Review"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("stars", type: .nonNull(.scalar(Int.self))),
+                GraphQLField("commentary", type: .scalar(String.self)),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public init(stars: Int, commentary: String? = nil) {
+                self.init(snapshot: ["__typename": "Review", "stars": stars, "commentary": commentary])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The number of stars this review gave, 1-5
+            public var stars: Int {
+                get {
+                    return snapshot["stars"]! as! Int
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "stars")
+                }
+            }
+
+            /// Comment about the movie
+            public var commentary: String? {
+                get {
+                    return snapshot["commentary"] as? String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "commentary")
+                }
+            }
+        }
     }
-
-    public var createReview: CreateReview? {
-      get {
-        return (snapshot["createReview"] as? Snapshot).flatMap { CreateReview(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "createReview")
-      }
-    }
-
-    public struct CreateReview: GraphQLSelectionSet {
-      public static let possibleTypes = ["Review"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("stars", type: .nonNull(.scalar(Int.self))),
-        GraphQLField("commentary", type: .scalar(String.self)),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public init(stars: Int, commentary: String? = nil) {
-        self.init(snapshot: ["__typename": "Review", "stars": stars, "commentary": commentary])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The number of stars this review gave, 1-5
-      public var stars: Int {
-        get {
-          return snapshot["stars"]! as! Int
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "stars")
-        }
-      }
-
-      /// Comment about the movie
-      public var commentary: String? {
-        get {
-          return snapshot["commentary"] as? String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "commentary")
-        }
-      }
-    }
-  }
 }
 
 public final class HeroAndFriendsNamesQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroAndFriendsNames($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    friends {\n      __typename\n      name\n    }\n  }\n}"
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        GraphQLField("friends", type: .list(.object(Friend.selections))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String, friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public static func makeDroid(name: String, friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      /// The friends of the character, or an empty list if they have none
-      public var friends: [Friend?]? {
-        get {
-          return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-        }
-        set {
-          snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-        }
-      }
-
-      public struct Friend: GraphQLSelectionSet {
-        public static let possibleTypes = ["Human", "Droid"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        ]
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
+            self.snapshot = snapshot
         }
 
-        public static func makeHuman(name: String) -> Friend {
-          return Friend(snapshot: ["__typename": "Human", "name": name])
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
         }
 
-        public static func makeDroid(name: String) -> Friend {
-          return Friend(snapshot: ["__typename": "Droid", "name": name])
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
         }
 
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
 
-        /// The name of the character
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                GraphQLField("friends", type: .list(.object(Friend.selections))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String, friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public static func makeDroid(name: String, friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            /// The friends of the character, or an empty list if they have none
+            public var friends: [Friend?]? {
+                get {
+                    return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+                }
+                set {
+                    snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+                }
+            }
+
+            public struct Friend: GraphQLSelectionSet {
+                public static let possibleTypes = ["Human", "Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public static func makeHuman(name: String) -> Friend {
+                    return Friend(snapshot: ["__typename": "Human", "name": name])
+                }
+
+                public static func makeDroid(name: String) -> Friend {
+                    return Friend(snapshot: ["__typename": "Droid", "name": name])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// The name of the character
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 public final class HeroAndFriendsNamesWithIDsQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroAndFriendsNamesWithIDs($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    id\n    name\n    friends {\n      __typename\n      id\n      name\n    }\n  }\n}"
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        GraphQLField("friends", type: .list(.object(Friend.selections))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(id: GraphQLID, name: String, friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "id": id, "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public static func makeDroid(id: GraphQLID, name: String, friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "id": id, "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The ID of the character
-      public var id: GraphQLID {
-        get {
-          return snapshot["id"]! as! GraphQLID
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "id")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      /// The friends of the character, or an empty list if they have none
-      public var friends: [Friend?]? {
-        get {
-          return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-        }
-        set {
-          snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-        }
-      }
-
-      public struct Friend: GraphQLSelectionSet {
-        public static let possibleTypes = ["Human", "Droid"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        ]
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
+            self.snapshot = snapshot
         }
 
-        public static func makeHuman(id: GraphQLID, name: String) -> Friend {
-          return Friend(snapshot: ["__typename": "Human", "id": id, "name": name])
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
         }
 
-        public static func makeDroid(id: GraphQLID, name: String) -> Friend {
-          return Friend(snapshot: ["__typename": "Droid", "id": id, "name": name])
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
         }
 
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
 
-        /// The ID of the character
-        public var id: GraphQLID {
-          get {
-            return snapshot["id"]! as! GraphQLID
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "id")
-          }
-        }
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                GraphQLField("friends", type: .list(.object(Friend.selections))),
+                ]
 
-        /// The name of the character
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(id: GraphQLID, name: String, friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "id": id, "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public static func makeDroid(id: GraphQLID, name: String, friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "id": id, "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The ID of the character
+            public var id: GraphQLID {
+                get {
+                    return snapshot["id"]! as! GraphQLID
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "id")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            /// The friends of the character, or an empty list if they have none
+            public var friends: [Friend?]? {
+                get {
+                    return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+                }
+                set {
+                    snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+                }
+            }
+
+            public struct Friend: GraphQLSelectionSet {
+                public static let possibleTypes = ["Human", "Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public static func makeHuman(id: GraphQLID, name: String) -> Friend {
+                    return Friend(snapshot: ["__typename": "Human", "id": id, "name": name])
+                }
+
+                public static func makeDroid(id: GraphQLID, name: String) -> Friend {
+                    return Friend(snapshot: ["__typename": "Droid", "id": id, "name": name])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// The ID of the character
+                public var id: GraphQLID {
+                    get {
+                        return snapshot["id"]! as! GraphQLID
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "id")
+                    }
+                }
+
+                /// The name of the character
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 public final class HeroAndFriendsNamesWithIdForParentOnlyQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroAndFriendsNamesWithIDForParentOnly($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    id\n    name\n    friends {\n      __typename\n      name\n    }\n  }\n}"
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        GraphQLField("friends", type: .list(.object(Friend.selections))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(id: GraphQLID, name: String, friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "id": id, "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public static func makeDroid(id: GraphQLID, name: String, friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "id": id, "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The ID of the character
-      public var id: GraphQLID {
-        get {
-          return snapshot["id"]! as! GraphQLID
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "id")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      /// The friends of the character, or an empty list if they have none
-      public var friends: [Friend?]? {
-        get {
-          return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-        }
-        set {
-          snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-        }
-      }
-
-      public struct Friend: GraphQLSelectionSet {
-        public static let possibleTypes = ["Human", "Droid"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        ]
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
+            self.snapshot = snapshot
         }
 
-        public static func makeHuman(name: String) -> Friend {
-          return Friend(snapshot: ["__typename": "Human", "name": name])
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
         }
 
-        public static func makeDroid(name: String) -> Friend {
-          return Friend(snapshot: ["__typename": "Droid", "name": name])
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
         }
 
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
 
-        /// The name of the character
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                GraphQLField("friends", type: .list(.object(Friend.selections))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(id: GraphQLID, name: String, friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "id": id, "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public static func makeDroid(id: GraphQLID, name: String, friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "id": id, "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The ID of the character
+            public var id: GraphQLID {
+                get {
+                    return snapshot["id"]! as! GraphQLID
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "id")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            /// The friends of the character, or an empty list if they have none
+            public var friends: [Friend?]? {
+                get {
+                    return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+                }
+                set {
+                    snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+                }
+            }
+
+            public struct Friend: GraphQLSelectionSet {
+                public static let possibleTypes = ["Human", "Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public static func makeHuman(name: String) -> Friend {
+                    return Friend(snapshot: ["__typename": "Human", "name": name])
+                }
+
+                public static func makeDroid(name: String) -> Friend {
+                    return Friend(snapshot: ["__typename": "Droid", "name": name])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// The name of the character
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 public final class HeroAndFriendsNamesWithFragmentQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroAndFriendsNamesWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    ...FriendsNames\n  }\n}"
 
-  public static var requestString: String { return operationString.appending(FriendsNames.fragmentString) }
+    public static var requestString: String { return operationString.appending(FriendsNames.fragmentString) }
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("friends", type: .list(.object(Friend.selections))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String, friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public static func makeDroid(name: String, friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      /// The friends of the character, or an empty list if they have none
-      public var friends: [Friend?]? {
-        get {
-          return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-        }
-        set {
-          snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-        }
-      }
-
-      public var fragments: Fragments {
-        get {
-          return Fragments(snapshot: snapshot)
-        }
-        set {
-          snapshot += newValue.snapshot
-        }
-      }
-
-      public struct Fragments {
-        public var snapshot: Snapshot
-
-        public var friendsNames: FriendsNames {
-          get {
-            return FriendsNames(snapshot: snapshot)
-          }
-          set {
-            snapshot += newValue.snapshot
-          }
-        }
-      }
-
-      public struct Friend: GraphQLSelectionSet {
-        public static let possibleTypes = ["Human", "Droid"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        ]
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
+            self.snapshot = snapshot
         }
 
-        public static func makeHuman(name: String) -> Friend {
-          return Friend(snapshot: ["__typename": "Human", "name": name])
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
         }
 
-        public static func makeDroid(name: String) -> Friend {
-          return Friend(snapshot: ["__typename": "Droid", "name": name])
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
         }
 
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
 
-        /// The name of the character
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("friends", type: .list(.object(Friend.selections))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String, friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public static func makeDroid(name: String, friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            /// The friends of the character, or an empty list if they have none
+            public var friends: [Friend?]? {
+                get {
+                    return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+                }
+                set {
+                    snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+                }
+            }
+
+            public var fragments: Fragments {
+                get {
+                    return Fragments(snapshot: snapshot)
+                }
+                set {
+                    snapshot += newValue.snapshot
+                }
+            }
+
+            public struct Fragments {
+                public var snapshot: Snapshot
+
+                public var friendsNames: FriendsNames {
+                    get {
+                        return FriendsNames(snapshot: snapshot)
+                    }
+                    set {
+                        snapshot += newValue.snapshot
+                    }
+                }
+            }
+
+            public struct Friend: GraphQLSelectionSet {
+                public static let possibleTypes = ["Human", "Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public static func makeHuman(name: String) -> Friend {
+                    return Friend(snapshot: ["__typename": "Human", "name": name])
+                }
+
+                public static func makeDroid(name: String) -> Friend {
+                    return Friend(snapshot: ["__typename": "Droid", "name": name])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// The name of the character
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 public final class HeroAndFriendsNamesWithFragmentTwiceQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroAndFriendsNamesWithFragmentTwice($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    friends {\n      __typename\n      ...CharacterName\n    }\n    ... on Droid {\n      friends {\n        __typename\n        ...CharacterName\n      }\n    }\n  }\n}"
 
-  public static var requestString: String { return operationString.appending(CharacterName.fragmentString) }
+    public static var requestString: String { return operationString.appending(CharacterName.fragmentString) }
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLTypeCase(
-          variants: ["Droid": AsDroid.selections],
-          default: [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("friends", type: .list(.object(Friend.selections))),
-          ]
-        )
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public static func makeDroid(friends: [AsDroid.Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The friends of the character, or an empty list if they have none
-      public var friends: [Friend?]? {
-        get {
-          return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-        }
-        set {
-          snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-        }
-      }
-
-      public struct Friend: GraphQLSelectionSet {
-        public static let possibleTypes = ["Human", "Droid"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        ]
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
-        }
-
-        public static func makeHuman(name: String) -> Friend {
-          return Friend(snapshot: ["__typename": "Human", "name": name])
-        }
-
-        public static func makeDroid(name: String) -> Friend {
-          return Friend(snapshot: ["__typename": "Droid", "name": name])
-        }
-
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
-
-        /// The name of the character
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
-        }
-
-        public var fragments: Fragments {
-          get {
-            return Fragments(snapshot: snapshot)
-          }
-          set {
-            snapshot += newValue.snapshot
-          }
-        }
-
-        public struct Fragments {
-          public var snapshot: Snapshot
-
-          public var characterName: CharacterName {
-            get {
-              return CharacterName(snapshot: snapshot)
-            }
-            set {
-              snapshot += newValue.snapshot
-            }
-          }
-        }
-      }
-
-      public var asDroid: AsDroid? {
-        get {
-          if !AsDroid.possibleTypes.contains(__typename) { return nil }
-          return AsDroid(snapshot: snapshot)
-        }
-        set {
-          guard let newValue = newValue else { return }
-          snapshot = newValue.snapshot
-        }
-      }
-
-      public struct AsDroid: GraphQLSelectionSet {
-        public static let possibleTypes = ["Droid"]
-
-        public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("friends", type: .list(.object(Friend.selections))),
-          GraphQLField("friends", type: .list(.object(Friend.selections))),
-        ]
-
-        public var snapshot: Snapshot
-
-        public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
-        }
-
-        public init(friends: [Friend?]? = nil) {
-          self.init(snapshot: ["__typename": "Droid", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-        }
-
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
-
-        /// This droid's friends, or an empty list if they have none
-        public var friends: [Friend?]? {
-          get {
-            return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-          }
-          set {
-            snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-          }
-        }
-
-        public struct Friend: GraphQLSelectionSet {
-          public static let possibleTypes = ["Human", "Droid"]
-
-          public static let selections: [GraphQLSelection] = [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          ]
-
-          public var snapshot: Snapshot
-
-          public init(snapshot: Snapshot) {
             self.snapshot = snapshot
-          }
+        }
 
-          public static func makeHuman(name: String) -> Friend {
-            return Friend(snapshot: ["__typename": "Human", "name": name])
-          }
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
 
-          public static func makeDroid(name: String) -> Friend {
-            return Friend(snapshot: ["__typename": "Droid", "name": name])
-          }
-
-          public var __typename: String {
+        public var hero: Hero? {
             get {
-              return snapshot["__typename"]! as! String
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
             }
             set {
-              snapshot.updateValue(newValue, forKey: "__typename")
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
             }
-          }
+        }
 
-          /// The name of the character
-          public var name: String {
-            get {
-              return snapshot["name"]! as! String
-            }
-            set {
-              snapshot.updateValue(newValue, forKey: "name")
-            }
-          }
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
 
-          public var fragments: Fragments {
-            get {
-              return Fragments(snapshot: snapshot)
-            }
-            set {
-              snapshot += newValue.snapshot
-            }
-          }
+            public static let selections: [GraphQLSelection] = [
+                GraphQLTypeCase(
+                    variants: ["Droid": AsDroid.selections],
+                    default: [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("friends", type: .list(.object(Friend.selections))),
+                        ]
+                )
+            ]
 
-          public struct Fragments {
             public var snapshot: Snapshot
 
-            public var characterName: CharacterName {
-              get {
-                return CharacterName(snapshot: snapshot)
-              }
-              set {
-                snapshot += newValue.snapshot
-              }
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
             }
-          }
+
+            public static func makeHuman(friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public static func makeDroid(friends: [AsDroid.Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The friends of the character, or an empty list if they have none
+            public var friends: [Friend?]? {
+                get {
+                    return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+                }
+                set {
+                    snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+                }
+            }
+
+            public struct Friend: GraphQLSelectionSet {
+                public static let possibleTypes = ["Human", "Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public static func makeHuman(name: String) -> Friend {
+                    return Friend(snapshot: ["__typename": "Human", "name": name])
+                }
+
+                public static func makeDroid(name: String) -> Friend {
+                    return Friend(snapshot: ["__typename": "Droid", "name": name])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// The name of the character
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+
+                public var fragments: Fragments {
+                    get {
+                        return Fragments(snapshot: snapshot)
+                    }
+                    set {
+                        snapshot += newValue.snapshot
+                    }
+                }
+
+                public struct Fragments {
+                    public var snapshot: Snapshot
+
+                    public var characterName: CharacterName {
+                        get {
+                            return CharacterName(snapshot: snapshot)
+                        }
+                        set {
+                            snapshot += newValue.snapshot
+                        }
+                    }
+                }
+            }
+
+            public var asDroid: AsDroid? {
+                get {
+                    if !AsDroid.possibleTypes.contains(__typename) { return nil }
+                    return AsDroid(snapshot: snapshot)
+                }
+                set {
+                    guard let newValue = newValue else { return }
+                    snapshot = newValue.snapshot
+                }
+            }
+
+            public struct AsDroid: GraphQLSelectionSet {
+                public static let possibleTypes = ["Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("friends", type: .list(.object(Friend.selections))),
+                    GraphQLField("friends", type: .list(.object(Friend.selections))),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public init(friends: [Friend?]? = nil) {
+                    self.init(snapshot: ["__typename": "Droid", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// This droid's friends, or an empty list if they have none
+                public var friends: [Friend?]? {
+                    get {
+                        return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+                    }
+                    set {
+                        snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+                    }
+                }
+
+                public struct Friend: GraphQLSelectionSet {
+                    public static let possibleTypes = ["Human", "Droid"]
+
+                    public static let selections: [GraphQLSelection] = [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        ]
+
+                    public var snapshot: Snapshot
+
+                    public init(snapshot: Snapshot) {
+                        self.snapshot = snapshot
+                    }
+
+                    public static func makeHuman(name: String) -> Friend {
+                        return Friend(snapshot: ["__typename": "Human", "name": name])
+                    }
+
+                    public static func makeDroid(name: String) -> Friend {
+                        return Friend(snapshot: ["__typename": "Droid", "name": name])
+                    }
+
+                    public var __typename: String {
+                        get {
+                            return snapshot["__typename"]! as! String
+                        }
+                        set {
+                            snapshot.updateValue(newValue, forKey: "__typename")
+                        }
+                    }
+
+                    /// The name of the character
+                    public var name: String {
+                        get {
+                            return snapshot["name"]! as! String
+                        }
+                        set {
+                            snapshot.updateValue(newValue, forKey: "name")
+                        }
+                    }
+
+                    public var fragments: Fragments {
+                        get {
+                            return Fragments(snapshot: snapshot)
+                        }
+                        set {
+                            snapshot += newValue.snapshot
+                        }
+                    }
+
+                    public struct Fragments {
+                        public var snapshot: Snapshot
+
+                        public var characterName: CharacterName {
+                            get {
+                                return CharacterName(snapshot: snapshot)
+                            }
+                            set {
+                                snapshot += newValue.snapshot
+                            }
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 public final class HeroAppearsInQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroAppearsIn {\n  hero {\n    __typename\n    appearsIn\n  }\n}"
 
-  public init() {
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init() {
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("hero", type: .object(Hero.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(appearsIn: [Episode?]) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "appearsIn": appearsIn])
+            }
+
+            public static func makeDroid(appearsIn: [Episode?]) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "appearsIn": appearsIn])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The movies this character appears in
+            public var appearsIn: [Episode?] {
+                get {
+                    return snapshot["appearsIn"]! as! [Episode?]
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "appearsIn")
+                }
+            }
+        }
     }
-
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(appearsIn: [Episode?]) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "appearsIn": appearsIn])
-      }
-
-      public static func makeDroid(appearsIn: [Episode?]) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "appearsIn": appearsIn])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The movies this character appears in
-      public var appearsIn: [Episode?] {
-        get {
-          return snapshot["appearsIn"]! as! [Episode?]
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "appearsIn")
-        }
-      }
-    }
-  }
 }
 
 public final class HeroAppearsInWithFragmentQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroAppearsInWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...CharacterAppearsIn\n  }\n}"
 
-  public static var requestString: String { return operationString.appending(CharacterAppearsIn.fragmentString) }
+    public static var requestString: String { return operationString.appending(CharacterAppearsIn.fragmentString) }
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(appearsIn: [Episode?]) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "appearsIn": appearsIn])
-      }
-
-      public static func makeDroid(appearsIn: [Episode?]) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "appearsIn": appearsIn])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The movies this character appears in
-      public var appearsIn: [Episode?] {
-        get {
-          return snapshot["appearsIn"]! as! [Episode?]
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "appearsIn")
-        }
-      }
-
-      public var fragments: Fragments {
-        get {
-          return Fragments(snapshot: snapshot)
-        }
-        set {
-          snapshot += newValue.snapshot
-        }
-      }
-
-      public struct Fragments {
         public var snapshot: Snapshot
 
-        public var characterAppearsIn: CharacterAppearsIn {
-          get {
-            return CharacterAppearsIn(snapshot: snapshot)
-          }
-          set {
-            snapshot += newValue.snapshot
-          }
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
         }
-      }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(appearsIn: [Episode?]) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "appearsIn": appearsIn])
+            }
+
+            public static func makeDroid(appearsIn: [Episode?]) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "appearsIn": appearsIn])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The movies this character appears in
+            public var appearsIn: [Episode?] {
+                get {
+                    return snapshot["appearsIn"]! as! [Episode?]
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "appearsIn")
+                }
+            }
+
+            public var fragments: Fragments {
+                get {
+                    return Fragments(snapshot: snapshot)
+                }
+                set {
+                    snapshot += newValue.snapshot
+                }
+            }
+
+            public struct Fragments {
+                public var snapshot: Snapshot
+
+                public var characterAppearsIn: CharacterAppearsIn {
+                    get {
+                        return CharacterAppearsIn(snapshot: snapshot)
+                    }
+                    set {
+                        snapshot += newValue.snapshot
+                    }
+                }
+            }
+        }
     }
-  }
 }
 
 public final class HeroNameConditionalExclusionQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroNameConditionalExclusion($skipName: Boolean!) {\n  hero {\n    __typename\n    name @skip(if: $skipName)\n  }\n}"
 
-  public var skipName: Bool
+    public var skipName: Bool
 
-  public init(skipName: Bool) {
-    self.skipName = skipName
-  }
-
-  public var variables: GraphQLMap? {
-    return ["skipName": skipName]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(skipName: Bool) {
+        self.skipName = skipName
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["skipName": skipName]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("hero", type: .object(Hero.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLBooleanCondition(variableName: "skipName", inverted: true, selections: [
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    ]),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name])
+            }
+
+            public static func makeDroid(name: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String? {
+                get {
+                    return snapshot["name"] as? String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+        }
     }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLBooleanCondition(variableName: "skipName", inverted: true, selections: [
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        ]),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name])
-      }
-
-      public static func makeDroid(name: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String? {
-        get {
-          return snapshot["name"] as? String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-    }
-  }
 }
 
 public final class HeroNameConditionalInclusionQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroNameConditionalInclusion($includeName: Boolean!) {\n  hero {\n    __typename\n    name @include(if: $includeName)\n  }\n}"
 
-  public var includeName: Bool
+    public var includeName: Bool
 
-  public init(includeName: Bool) {
-    self.includeName = includeName
-  }
-
-  public var variables: GraphQLMap? {
-    return ["includeName": includeName]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(includeName: Bool) {
+        self.includeName = includeName
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["includeName": includeName]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("hero", type: .object(Hero.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLBooleanCondition(variableName: "includeName", inverted: false, selections: [
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    ]),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name])
+            }
+
+            public static func makeDroid(name: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String? {
+                get {
+                    return snapshot["name"] as? String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+        }
     }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLBooleanCondition(variableName: "includeName", inverted: false, selections: [
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        ]),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name])
-      }
-
-      public static func makeDroid(name: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String? {
-        get {
-          return snapshot["name"] as? String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-    }
-  }
 }
 
 public final class HeroNameConditionalBothQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroNameConditionalBoth($skipName: Boolean!, $includeName: Boolean!) {\n  hero {\n    __typename\n    name @skip(if: $skipName) @include(if: $includeName)\n  }\n}"
 
-  public var skipName: Bool
-  public var includeName: Bool
+    public var skipName: Bool
+    public var includeName: Bool
 
-  public init(skipName: Bool, includeName: Bool) {
-    self.skipName = skipName
-    self.includeName = includeName
-  }
-
-  public var variables: GraphQLMap? {
-    return ["skipName": skipName, "includeName": includeName]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(skipName: Bool, includeName: Bool) {
+        self.skipName = skipName
+        self.includeName = includeName
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["skipName": skipName, "includeName": includeName]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("hero", type: .object(Hero.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLBooleanCondition(variableName: "includeName", inverted: false, selections: [
+                    GraphQLBooleanCondition(variableName: "skipName", inverted: true, selections: [
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        ]),
+                    ]),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name])
+            }
+
+            public static func makeDroid(name: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String? {
+                get {
+                    return snapshot["name"] as? String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+        }
     }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLBooleanCondition(variableName: "includeName", inverted: false, selections: [
-          GraphQLBooleanCondition(variableName: "skipName", inverted: true, selections: [
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          ]),
-        ]),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name])
-      }
-
-      public static func makeDroid(name: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String? {
-        get {
-          return snapshot["name"] as? String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-    }
-  }
 }
 
 public final class HeroNameConditionalBothSeparateQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroNameConditionalBothSeparate($skipName: Boolean!, $includeName: Boolean!) {\n  hero {\n    __typename\n    name @skip(if: $skipName)\n    name @include(if: $includeName)\n  }\n}"
 
-  public var skipName: Bool
-  public var includeName: Bool
+    public var skipName: Bool
+    public var includeName: Bool
 
-  public init(skipName: Bool, includeName: Bool) {
-    self.skipName = skipName
-    self.includeName = includeName
-  }
-
-  public var variables: GraphQLMap? {
-    return ["skipName": skipName, "includeName": includeName]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(skipName: Bool, includeName: Bool) {
+        self.skipName = skipName
+        self.includeName = includeName
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["skipName": skipName, "includeName": includeName]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("hero", type: .object(Hero.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLBooleanCondition(variableName: "skipName", inverted: true, selections: [
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    ]),
+                GraphQLBooleanCondition(variableName: "includeName", inverted: false, selections: [
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    ]),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name])
+            }
+
+            public static func makeDroid(name: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String? {
+                get {
+                    return snapshot["name"] as? String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+        }
     }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLBooleanCondition(variableName: "skipName", inverted: true, selections: [
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        ]),
-        GraphQLBooleanCondition(variableName: "includeName", inverted: false, selections: [
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        ]),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name])
-      }
-
-      public static func makeDroid(name: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String? {
-        get {
-          return snapshot["name"] as? String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-    }
-  }
 }
 
 public final class HeroDetailsInlineConditionalInclusionQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroDetailsInlineConditionalInclusion($includeDetails: Boolean!) {\n  hero {\n    __typename\n    ... @include(if: $includeDetails) {\n      name\n      appearsIn\n    }\n  }\n}"
 
-  public var includeDetails: Bool
+    public var includeDetails: Bool
 
-  public init(includeDetails: Bool) {
-    self.includeDetails = includeDetails
-  }
-
-  public var variables: GraphQLMap? {
-    return ["includeDetails": includeDetails]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(includeDetails: Bool) {
+        self.includeDetails = includeDetails
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["includeDetails": includeDetails]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("hero", type: .object(Hero.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLBooleanCondition(variableName: "includeDetails", inverted: false, selections: [
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
+                    ]),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String? = nil, appearsIn: [Episode?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name, "appearsIn": appearsIn])
+            }
+
+            public static func makeDroid(name: String? = nil, appearsIn: [Episode?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name, "appearsIn": appearsIn])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String? {
+                get {
+                    return snapshot["name"] as? String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            /// The movies this character appears in
+            public var appearsIn: [Episode?]? {
+                get {
+                    return snapshot["appearsIn"] as? [Episode?]
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "appearsIn")
+                }
+            }
+        }
     }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLBooleanCondition(variableName: "includeDetails", inverted: false, selections: [
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
-        ]),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String? = nil, appearsIn: [Episode?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name, "appearsIn": appearsIn])
-      }
-
-      public static func makeDroid(name: String? = nil, appearsIn: [Episode?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name, "appearsIn": appearsIn])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String? {
-        get {
-          return snapshot["name"] as? String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      /// The movies this character appears in
-      public var appearsIn: [Episode?]? {
-        get {
-          return snapshot["appearsIn"] as? [Episode?]
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "appearsIn")
-        }
-      }
-    }
-  }
 }
 
 public final class HeroDetailsFragmentConditionalInclusionQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroDetailsFragmentConditionalInclusion($includeDetails: Boolean!) {\n  hero {\n    __typename\n    ...HeroDetails @include(if: $includeDetails)\n  }\n}"
 
-  public static var requestString: String { return operationString.appending(HeroDetails.fragmentString) }
+    public static var requestString: String { return operationString.appending(HeroDetails.fragmentString) }
 
-  public var includeDetails: Bool
+    public var includeDetails: Bool
 
-  public init(includeDetails: Bool) {
-    self.includeDetails = includeDetails
-  }
-
-  public var variables: GraphQLMap? {
-    return ["includeDetails": includeDetails]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(includeDetails: Bool) {
+        self.includeDetails = includeDetails
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["includeDetails": includeDetails]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLTypeCase(
-          variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections],
-          default: [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLBooleanCondition(variableName: "includeDetails", inverted: false, selections: [
-              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-              GraphQLField("name", type: .nonNull(.scalar(String.self))),
-            ]),
-          ]
-        )
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String? = nil, height: Double? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name, "height": height])
-      }
-
-      public static func makeDroid(name: String? = nil, primaryFunction: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String? {
-        get {
-          return snapshot["name"] as? String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      public var fragments: Fragments {
-        get {
-          return Fragments(snapshot: snapshot)
-        }
-        set {
-          snapshot += newValue.snapshot
-        }
-      }
-
-      public struct Fragments {
-        public var snapshot: Snapshot
-
-        public var heroDetails: HeroDetails {
-          get {
-            return HeroDetails(snapshot: snapshot)
-          }
-          set {
-            snapshot += newValue.snapshot
-          }
-        }
-      }
-
-      public var asHuman: AsHuman? {
-        get {
-          if !AsHuman.possibleTypes.contains(__typename) { return nil }
-          return AsHuman(snapshot: snapshot)
-        }
-        set {
-          guard let newValue = newValue else { return }
-          snapshot = newValue.snapshot
-        }
-      }
-
-      public struct AsHuman: GraphQLSelectionSet {
-        public static let possibleTypes = ["Human"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLBooleanCondition(variableName: "includeDetails", inverted: false, selections: [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          ]),
-          GraphQLBooleanCondition(variableName: "includeDetails", inverted: false, selections: [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-            GraphQLField("height", type: .scalar(Double.self)),
-          ]),
-        ]
+            GraphQLField("hero", type: .object(Hero.selections)),
+            ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
+            self.snapshot = snapshot
         }
 
-        public init(name: String? = nil, height: Double? = nil) {
-          self.init(snapshot: ["__typename": "Human", "name": name, "height": height])
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
         }
 
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
-
-        /// What this human calls themselves
-        public var name: String? {
-          get {
-            return snapshot["name"] as? String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
-        }
-
-        /// Height in the preferred unit, default is meters
-        public var height: Double? {
-          get {
-            return snapshot["height"] as? Double
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "height")
-          }
-        }
-
-        public var fragments: Fragments {
-          get {
-            return Fragments(snapshot: snapshot)
-          }
-          set {
-            snapshot += newValue.snapshot
-          }
-        }
-
-        public struct Fragments {
-          public var snapshot: Snapshot
-
-          public var heroDetails: HeroDetails {
+        public var hero: Hero? {
             get {
-              return HeroDetails(snapshot: snapshot)
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
             }
             set {
-              snapshot += newValue.snapshot
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
             }
-          }
-        }
-      }
-
-      public var asDroid: AsDroid? {
-        get {
-          if !AsDroid.possibleTypes.contains(__typename) { return nil }
-          return AsDroid(snapshot: snapshot)
-        }
-        set {
-          guard let newValue = newValue else { return }
-          snapshot = newValue.snapshot
-        }
-      }
-
-      public struct AsDroid: GraphQLSelectionSet {
-        public static let possibleTypes = ["Droid"]
-
-        public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLBooleanCondition(variableName: "includeDetails", inverted: false, selections: [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          ]),
-          GraphQLBooleanCondition(variableName: "includeDetails", inverted: false, selections: [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-            GraphQLField("primaryFunction", type: .scalar(String.self)),
-          ]),
-        ]
-
-        public var snapshot: Snapshot
-
-        public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
         }
 
-        public init(name: String? = nil, primaryFunction: String? = nil) {
-          self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-        }
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
 
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
+            public static let selections: [GraphQLSelection] = [
+                GraphQLTypeCase(
+                    variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections],
+                    default: [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLBooleanCondition(variableName: "includeDetails", inverted: false, selections: [
+                            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                            ]),
+                        ]
+                )
+            ]
 
-        /// What others call this droid
-        public var name: String? {
-          get {
-            return snapshot["name"] as? String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
-        }
+            public var snapshot: Snapshot
 
-        /// This droid's primary function
-        public var primaryFunction: String? {
-          get {
-            return snapshot["primaryFunction"] as? String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "primaryFunction")
-          }
-        }
-
-        public var fragments: Fragments {
-          get {
-            return Fragments(snapshot: snapshot)
-          }
-          set {
-            snapshot += newValue.snapshot
-          }
-        }
-
-        public struct Fragments {
-          public var snapshot: Snapshot
-
-          public var heroDetails: HeroDetails {
-            get {
-              return HeroDetails(snapshot: snapshot)
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
             }
-            set {
-              snapshot += newValue.snapshot
+
+            public static func makeHuman(name: String? = nil, height: Double? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name, "height": height])
             }
-          }
+
+            public static func makeDroid(name: String? = nil, primaryFunction: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String? {
+                get {
+                    return snapshot["name"] as? String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            public var fragments: Fragments {
+                get {
+                    return Fragments(snapshot: snapshot)
+                }
+                set {
+                    snapshot += newValue.snapshot
+                }
+            }
+
+            public struct Fragments {
+                public var snapshot: Snapshot
+
+                public var heroDetails: HeroDetails {
+                    get {
+                        return HeroDetails(snapshot: snapshot)
+                    }
+                    set {
+                        snapshot += newValue.snapshot
+                    }
+                }
+            }
+
+            public var asHuman: AsHuman? {
+                get {
+                    if !AsHuman.possibleTypes.contains(__typename) { return nil }
+                    return AsHuman(snapshot: snapshot)
+                }
+                set {
+                    guard let newValue = newValue else { return }
+                    snapshot = newValue.snapshot
+                }
+            }
+
+            public struct AsHuman: GraphQLSelectionSet {
+                public static let possibleTypes = ["Human"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLBooleanCondition(variableName: "includeDetails", inverted: false, selections: [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        ]),
+                    GraphQLBooleanCondition(variableName: "includeDetails", inverted: false, selections: [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("height", type: .scalar(Double.self)),
+                        ]),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public init(name: String? = nil, height: Double? = nil) {
+                    self.init(snapshot: ["__typename": "Human", "name": name, "height": height])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// What this human calls themselves
+                public var name: String? {
+                    get {
+                        return snapshot["name"] as? String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+
+                /// Height in the preferred unit, default is meters
+                public var height: Double? {
+                    get {
+                        return snapshot["height"] as? Double
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "height")
+                    }
+                }
+
+                public var fragments: Fragments {
+                    get {
+                        return Fragments(snapshot: snapshot)
+                    }
+                    set {
+                        snapshot += newValue.snapshot
+                    }
+                }
+
+                public struct Fragments {
+                    public var snapshot: Snapshot
+
+                    public var heroDetails: HeroDetails {
+                        get {
+                            return HeroDetails(snapshot: snapshot)
+                        }
+                        set {
+                            snapshot += newValue.snapshot
+                        }
+                    }
+                }
+            }
+
+            public var asDroid: AsDroid? {
+                get {
+                    if !AsDroid.possibleTypes.contains(__typename) { return nil }
+                    return AsDroid(snapshot: snapshot)
+                }
+                set {
+                    guard let newValue = newValue else { return }
+                    snapshot = newValue.snapshot
+                }
+            }
+
+            public struct AsDroid: GraphQLSelectionSet {
+                public static let possibleTypes = ["Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLBooleanCondition(variableName: "includeDetails", inverted: false, selections: [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        ]),
+                    GraphQLBooleanCondition(variableName: "includeDetails", inverted: false, selections: [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("primaryFunction", type: .scalar(String.self)),
+                        ]),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public init(name: String? = nil, primaryFunction: String? = nil) {
+                    self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// What others call this droid
+                public var name: String? {
+                    get {
+                        return snapshot["name"] as? String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+
+                /// This droid's primary function
+                public var primaryFunction: String? {
+                    get {
+                        return snapshot["primaryFunction"] as? String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "primaryFunction")
+                    }
+                }
+
+                public var fragments: Fragments {
+                    get {
+                        return Fragments(snapshot: snapshot)
+                    }
+                    set {
+                        snapshot += newValue.snapshot
+                    }
+                }
+
+                public struct Fragments {
+                    public var snapshot: Snapshot
+
+                    public var heroDetails: HeroDetails {
+                        get {
+                            return HeroDetails(snapshot: snapshot)
+                        }
+                        set {
+                            snapshot += newValue.snapshot
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 public final class HeroNameTypeSpecificConditionalInclusionQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroNameTypeSpecificConditionalInclusion($episode: Episode, $includeName: Boolean!) {\n  hero(episode: $episode) {\n    __typename\n    name @include(if: $includeName)\n    ... on Droid {\n      name\n    }\n  }\n}"
 
-  public var episode: Episode?
-  public var includeName: Bool
+    public var episode: Episode?
+    public var includeName: Bool
 
-  public init(episode: Episode? = nil, includeName: Bool) {
-    self.episode = episode
-    self.includeName = includeName
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode, "includeName": includeName]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil, includeName: Bool) {
+        self.episode = episode
+        self.includeName = includeName
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode, "includeName": includeName]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLTypeCase(
-          variants: ["Droid": AsDroid.selections],
-          default: [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLBooleanCondition(variableName: "includeName", inverted: false, selections: [
-              GraphQLField("name", type: .nonNull(.scalar(String.self))),
-            ]),
-          ]
-        )
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name])
-      }
-
-      public static func makeDroid(name: String) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String? {
-        get {
-          return snapshot["name"] as? String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      public var asDroid: AsDroid? {
-        get {
-          if !AsDroid.possibleTypes.contains(__typename) { return nil }
-          return AsDroid(snapshot: snapshot)
-        }
-        set {
-          guard let newValue = newValue else { return }
-          snapshot = newValue.snapshot
-        }
-      }
-
-      public struct AsDroid: GraphQLSelectionSet {
-        public static let possibleTypes = ["Droid"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLBooleanCondition(variableName: "includeName", inverted: false, selections: [
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          ]),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        ]
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
+            self.snapshot = snapshot
         }
 
-        public init(name: String) {
-          self.init(snapshot: ["__typename": "Droid", "name": name])
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
         }
 
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
         }
 
-        /// What others call this droid
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLTypeCase(
+                    variants: ["Droid": AsDroid.selections],
+                    default: [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLBooleanCondition(variableName: "includeName", inverted: false, selections: [
+                            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                            ]),
+                        ]
+                )
+            ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name])
+            }
+
+            public static func makeDroid(name: String) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String? {
+                get {
+                    return snapshot["name"] as? String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            public var asDroid: AsDroid? {
+                get {
+                    if !AsDroid.possibleTypes.contains(__typename) { return nil }
+                    return AsDroid(snapshot: snapshot)
+                }
+                set {
+                    guard let newValue = newValue else { return }
+                    snapshot = newValue.snapshot
+                }
+            }
+
+            public struct AsDroid: GraphQLSelectionSet {
+                public static let possibleTypes = ["Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLBooleanCondition(variableName: "includeName", inverted: false, selections: [
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        ]),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public init(name: String) {
+                    self.init(snapshot: ["__typename": "Droid", "name": name])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// What others call this droid
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 public final class HeroFriendsDetailsConditionalInclusionQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroFriendsDetailsConditionalInclusion($includeFriendsDetails: Boolean!) {\n  hero {\n    __typename\n    friends @include(if: $includeFriendsDetails) {\n      __typename\n      name\n      ... on Droid {\n        primaryFunction\n      }\n    }\n  }\n}"
 
-  public var includeFriendsDetails: Bool
+    public var includeFriendsDetails: Bool
 
-  public init(includeFriendsDetails: Bool) {
-    self.includeFriendsDetails = includeFriendsDetails
-  }
-
-  public var variables: GraphQLMap? {
-    return ["includeFriendsDetails": includeFriendsDetails]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(includeFriendsDetails: Bool) {
+        self.includeFriendsDetails = includeFriendsDetails
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["includeFriendsDetails": includeFriendsDetails]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLBooleanCondition(variableName: "includeFriendsDetails", inverted: false, selections: [
-          GraphQLField("friends", type: .list(.object(Friend.selections))),
-        ]),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public static func makeDroid(friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The friends of the character, or an empty list if they have none
-      public var friends: [Friend?]? {
-        get {
-          return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-        }
-        set {
-          snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-        }
-      }
-
-      public struct Friend: GraphQLSelectionSet {
-        public static let possibleTypes = ["Human", "Droid"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLTypeCase(
-            variants: ["Droid": AsDroid.selections],
-            default: [
-              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-              GraphQLField("name", type: .nonNull(.scalar(String.self))),
+            GraphQLField("hero", type: .object(Hero.selections)),
             ]
-          )
-        ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
-        }
-
-        public static func makeHuman(name: String) -> Friend {
-          return Friend(snapshot: ["__typename": "Human", "name": name])
-        }
-
-        public static func makeDroid(name: String, primaryFunction: String? = nil) -> Friend {
-          return Friend(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-        }
-
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
-
-        /// The name of the character
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
-        }
-
-        public var asDroid: AsDroid? {
-          get {
-            if !AsDroid.possibleTypes.contains(__typename) { return nil }
-            return AsDroid(snapshot: snapshot)
-          }
-          set {
-            guard let newValue = newValue else { return }
-            snapshot = newValue.snapshot
-          }
-        }
-
-        public struct AsDroid: GraphQLSelectionSet {
-          public static let possibleTypes = ["Droid"]
-
-          public static let selections: [GraphQLSelection] = [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-            GraphQLField("primaryFunction", type: .scalar(String.self)),
-          ]
-
-          public var snapshot: Snapshot
-
-          public init(snapshot: Snapshot) {
             self.snapshot = snapshot
-          }
-
-          public init(name: String, primaryFunction: String? = nil) {
-            self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-          }
-
-          public var __typename: String {
-            get {
-              return snapshot["__typename"]! as! String
-            }
-            set {
-              snapshot.updateValue(newValue, forKey: "__typename")
-            }
-          }
-
-          /// What others call this droid
-          public var name: String {
-            get {
-              return snapshot["name"]! as! String
-            }
-            set {
-              snapshot.updateValue(newValue, forKey: "name")
-            }
-          }
-
-          /// This droid's primary function
-          public var primaryFunction: String? {
-            get {
-              return snapshot["primaryFunction"] as? String
-            }
-            set {
-              snapshot.updateValue(newValue, forKey: "primaryFunction")
-            }
-          }
         }
-      }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLBooleanCondition(variableName: "includeFriendsDetails", inverted: false, selections: [
+                    GraphQLField("friends", type: .list(.object(Friend.selections))),
+                    ]),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public static func makeDroid(friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The friends of the character, or an empty list if they have none
+            public var friends: [Friend?]? {
+                get {
+                    return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+                }
+                set {
+                    snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+                }
+            }
+
+            public struct Friend: GraphQLSelectionSet {
+                public static let possibleTypes = ["Human", "Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLTypeCase(
+                        variants: ["Droid": AsDroid.selections],
+                        default: [
+                            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                            ]
+                    )
+                ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public static func makeHuman(name: String) -> Friend {
+                    return Friend(snapshot: ["__typename": "Human", "name": name])
+                }
+
+                public static func makeDroid(name: String, primaryFunction: String? = nil) -> Friend {
+                    return Friend(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// The name of the character
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+
+                public var asDroid: AsDroid? {
+                    get {
+                        if !AsDroid.possibleTypes.contains(__typename) { return nil }
+                        return AsDroid(snapshot: snapshot)
+                    }
+                    set {
+                        guard let newValue = newValue else { return }
+                        snapshot = newValue.snapshot
+                    }
+                }
+
+                public struct AsDroid: GraphQLSelectionSet {
+                    public static let possibleTypes = ["Droid"]
+
+                    public static let selections: [GraphQLSelection] = [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("primaryFunction", type: .scalar(String.self)),
+                        ]
+
+                    public var snapshot: Snapshot
+
+                    public init(snapshot: Snapshot) {
+                        self.snapshot = snapshot
+                    }
+
+                    public init(name: String, primaryFunction: String? = nil) {
+                        self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+                    }
+
+                    public var __typename: String {
+                        get {
+                            return snapshot["__typename"]! as! String
+                        }
+                        set {
+                            snapshot.updateValue(newValue, forKey: "__typename")
+                        }
+                    }
+
+                    /// What others call this droid
+                    public var name: String {
+                        get {
+                            return snapshot["name"]! as! String
+                        }
+                        set {
+                            snapshot.updateValue(newValue, forKey: "name")
+                        }
+                    }
+
+                    /// This droid's primary function
+                    public var primaryFunction: String? {
+                        get {
+                            return snapshot["primaryFunction"] as? String
+                        }
+                        set {
+                            snapshot.updateValue(newValue, forKey: "primaryFunction")
+                        }
+                    }
+                }
+            }
+        }
     }
-  }
 }
 
 public final class HeroFriendsDetailsUnconditionalAndConditionalInclusionQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroFriendsDetailsUnconditionalAndConditionalInclusion($includeFriendsDetails: Boolean!) {\n  hero {\n    __typename\n    friends {\n      __typename\n      name\n    }\n    friends @include(if: $includeFriendsDetails) {\n      __typename\n      name\n      ... on Droid {\n        primaryFunction\n      }\n    }\n  }\n}"
 
-  public var includeFriendsDetails: Bool
+    public var includeFriendsDetails: Bool
 
-  public init(includeFriendsDetails: Bool) {
-    self.includeFriendsDetails = includeFriendsDetails
-  }
-
-  public var variables: GraphQLMap? {
-    return ["includeFriendsDetails": includeFriendsDetails]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(includeFriendsDetails: Bool) {
+        self.includeFriendsDetails = includeFriendsDetails
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["includeFriendsDetails": includeFriendsDetails]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("friends", type: .list(.object(Friend.selections))),
-        GraphQLBooleanCondition(variableName: "includeFriendsDetails", inverted: false, selections: [
-          GraphQLField("friends", type: .list(.object(Friend.selections))),
-        ]),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public static func makeDroid(friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The friends of the character, or an empty list if they have none
-      public var friends: [Friend?]? {
-        get {
-          return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-        }
-        set {
-          snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-        }
-      }
-
-      public struct Friend: GraphQLSelectionSet {
-        public static let possibleTypes = ["Human", "Droid"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLTypeCase(
-            variants: ["Droid": AsDroid.selections],
-            default: [
-              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-              GraphQLField("name", type: .nonNull(.scalar(String.self))),
-              GraphQLBooleanCondition(variableName: "includeFriendsDetails", inverted: false, selections: [
-                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-                GraphQLField("name", type: .nonNull(.scalar(String.self))),
-              ]),
+            GraphQLField("hero", type: .object(Hero.selections)),
             ]
-          )
-        ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
-        }
-
-        public static func makeHuman(name: String) -> Friend {
-          return Friend(snapshot: ["__typename": "Human", "name": name])
-        }
-
-        public static func makeDroid(name: String, primaryFunction: String? = nil) -> Friend {
-          return Friend(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-        }
-
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
-
-        /// The name of the character
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
-        }
-
-        public var asDroid: AsDroid? {
-          get {
-            if !AsDroid.possibleTypes.contains(__typename) { return nil }
-            return AsDroid(snapshot: snapshot)
-          }
-          set {
-            guard let newValue = newValue else { return }
-            snapshot = newValue.snapshot
-          }
-        }
-
-        public struct AsDroid: GraphQLSelectionSet {
-          public static let possibleTypes = ["Droid"]
-
-          public static let selections: [GraphQLSelection] = [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-            GraphQLBooleanCondition(variableName: "includeFriendsDetails", inverted: false, selections: [
-              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-              GraphQLField("name", type: .nonNull(.scalar(String.self))),
-            ]),
-            GraphQLBooleanCondition(variableName: "includeFriendsDetails", inverted: false, selections: [
-              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-              GraphQLField("name", type: .nonNull(.scalar(String.self))),
-              GraphQLField("primaryFunction", type: .scalar(String.self)),
-            ]),
-          ]
-
-          public var snapshot: Snapshot
-
-          public init(snapshot: Snapshot) {
             self.snapshot = snapshot
-          }
-
-          public init(name: String, primaryFunction: String? = nil) {
-            self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-          }
-
-          public var __typename: String {
-            get {
-              return snapshot["__typename"]! as! String
-            }
-            set {
-              snapshot.updateValue(newValue, forKey: "__typename")
-            }
-          }
-
-          /// What others call this droid
-          public var name: String {
-            get {
-              return snapshot["name"]! as! String
-            }
-            set {
-              snapshot.updateValue(newValue, forKey: "name")
-            }
-          }
-
-          /// This droid's primary function
-          public var primaryFunction: String? {
-            get {
-              return snapshot["primaryFunction"] as? String
-            }
-            set {
-              snapshot.updateValue(newValue, forKey: "primaryFunction")
-            }
-          }
         }
-      }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("friends", type: .list(.object(Friend.selections))),
+                GraphQLBooleanCondition(variableName: "includeFriendsDetails", inverted: false, selections: [
+                    GraphQLField("friends", type: .list(.object(Friend.selections))),
+                    ]),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public static func makeDroid(friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The friends of the character, or an empty list if they have none
+            public var friends: [Friend?]? {
+                get {
+                    return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+                }
+                set {
+                    snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+                }
+            }
+
+            public struct Friend: GraphQLSelectionSet {
+                public static let possibleTypes = ["Human", "Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLTypeCase(
+                        variants: ["Droid": AsDroid.selections],
+                        default: [
+                            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                            GraphQLBooleanCondition(variableName: "includeFriendsDetails", inverted: false, selections: [
+                                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                                ]),
+                            ]
+                    )
+                ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public static func makeHuman(name: String) -> Friend {
+                    return Friend(snapshot: ["__typename": "Human", "name": name])
+                }
+
+                public static func makeDroid(name: String, primaryFunction: String? = nil) -> Friend {
+                    return Friend(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// The name of the character
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+
+                public var asDroid: AsDroid? {
+                    get {
+                        if !AsDroid.possibleTypes.contains(__typename) { return nil }
+                        return AsDroid(snapshot: snapshot)
+                    }
+                    set {
+                        guard let newValue = newValue else { return }
+                        snapshot = newValue.snapshot
+                    }
+                }
+
+                public struct AsDroid: GraphQLSelectionSet {
+                    public static let possibleTypes = ["Droid"]
+
+                    public static let selections: [GraphQLSelection] = [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        GraphQLBooleanCondition(variableName: "includeFriendsDetails", inverted: false, selections: [
+                            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                            ]),
+                        GraphQLBooleanCondition(variableName: "includeFriendsDetails", inverted: false, selections: [
+                            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                            GraphQLField("primaryFunction", type: .scalar(String.self)),
+                            ]),
+                        ]
+
+                    public var snapshot: Snapshot
+
+                    public init(snapshot: Snapshot) {
+                        self.snapshot = snapshot
+                    }
+
+                    public init(name: String, primaryFunction: String? = nil) {
+                        self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+                    }
+
+                    public var __typename: String {
+                        get {
+                            return snapshot["__typename"]! as! String
+                        }
+                        set {
+                            snapshot.updateValue(newValue, forKey: "__typename")
+                        }
+                    }
+
+                    /// What others call this droid
+                    public var name: String {
+                        get {
+                            return snapshot["name"]! as! String
+                        }
+                        set {
+                            snapshot.updateValue(newValue, forKey: "name")
+                        }
+                    }
+
+                    /// This droid's primary function
+                    public var primaryFunction: String? {
+                        get {
+                            return snapshot["primaryFunction"] as? String
+                        }
+                        set {
+                            snapshot.updateValue(newValue, forKey: "primaryFunction")
+                        }
+                    }
+                }
+            }
+        }
     }
-  }
 }
 
 public final class HeroDetailsQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroDetails($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    ... on Human {\n      height\n    }\n    ... on Droid {\n      primaryFunction\n    }\n  }\n}"
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLTypeCase(
-          variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections],
-          default: [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          ]
-        )
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String, height: Double? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name, "height": height])
-      }
-
-      public static func makeDroid(name: String, primaryFunction: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      public var asHuman: AsHuman? {
-        get {
-          if !AsHuman.possibleTypes.contains(__typename) { return nil }
-          return AsHuman(snapshot: snapshot)
-        }
-        set {
-          guard let newValue = newValue else { return }
-          snapshot = newValue.snapshot
-        }
-      }
-
-      public struct AsHuman: GraphQLSelectionSet {
-        public static let possibleTypes = ["Human"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          GraphQLField("height", type: .scalar(Double.self)),
-        ]
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
+            self.snapshot = snapshot
         }
 
-        public init(name: String, height: Double? = nil) {
-          self.init(snapshot: ["__typename": "Human", "name": name, "height": height])
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
         }
 
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
         }
 
-        /// What this human calls themselves
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLTypeCase(
+                    variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections],
+                    default: [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        ]
+                )
+            ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String, height: Double? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name, "height": height])
+            }
+
+            public static func makeDroid(name: String, primaryFunction: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            public var asHuman: AsHuman? {
+                get {
+                    if !AsHuman.possibleTypes.contains(__typename) { return nil }
+                    return AsHuman(snapshot: snapshot)
+                }
+                set {
+                    guard let newValue = newValue else { return }
+                    snapshot = newValue.snapshot
+                }
+            }
+
+            public struct AsHuman: GraphQLSelectionSet {
+                public static let possibleTypes = ["Human"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("height", type: .scalar(Double.self)),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public init(name: String, height: Double? = nil) {
+                    self.init(snapshot: ["__typename": "Human", "name": name, "height": height])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// What this human calls themselves
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+
+                /// Height in the preferred unit, default is meters
+                public var height: Double? {
+                    get {
+                        return snapshot["height"] as? Double
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "height")
+                    }
+                }
+            }
+
+            public var asDroid: AsDroid? {
+                get {
+                    if !AsDroid.possibleTypes.contains(__typename) { return nil }
+                    return AsDroid(snapshot: snapshot)
+                }
+                set {
+                    guard let newValue = newValue else { return }
+                    snapshot = newValue.snapshot
+                }
+            }
+
+            public struct AsDroid: GraphQLSelectionSet {
+                public static let possibleTypes = ["Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("primaryFunction", type: .scalar(String.self)),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public init(name: String, primaryFunction: String? = nil) {
+                    self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// What others call this droid
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+
+                /// This droid's primary function
+                public var primaryFunction: String? {
+                    get {
+                        return snapshot["primaryFunction"] as? String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "primaryFunction")
+                    }
+                }
+            }
         }
-
-        /// Height in the preferred unit, default is meters
-        public var height: Double? {
-          get {
-            return snapshot["height"] as? Double
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "height")
-          }
-        }
-      }
-
-      public var asDroid: AsDroid? {
-        get {
-          if !AsDroid.possibleTypes.contains(__typename) { return nil }
-          return AsDroid(snapshot: snapshot)
-        }
-        set {
-          guard let newValue = newValue else { return }
-          snapshot = newValue.snapshot
-        }
-      }
-
-      public struct AsDroid: GraphQLSelectionSet {
-        public static let possibleTypes = ["Droid"]
-
-        public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          GraphQLField("primaryFunction", type: .scalar(String.self)),
-        ]
-
-        public var snapshot: Snapshot
-
-        public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
-        }
-
-        public init(name: String, primaryFunction: String? = nil) {
-          self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-        }
-
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
-
-        /// What others call this droid
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
-        }
-
-        /// This droid's primary function
-        public var primaryFunction: String? {
-          get {
-            return snapshot["primaryFunction"] as? String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "primaryFunction")
-          }
-        }
-      }
     }
-  }
 }
 
 public final class HeroDetailsWithFragmentQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroDetailsWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...HeroDetails\n  }\n}"
 
-  public static var requestString: String { return operationString.appending(HeroDetails.fragmentString) }
+    public static var requestString: String { return operationString.appending(HeroDetails.fragmentString) }
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLTypeCase(
-          variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections],
-          default: [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          ]
-        )
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String, height: Double? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name, "height": height])
-      }
-
-      public static func makeDroid(name: String, primaryFunction: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      public var fragments: Fragments {
-        get {
-          return Fragments(snapshot: snapshot)
-        }
-        set {
-          snapshot += newValue.snapshot
-        }
-      }
-
-      public struct Fragments {
-        public var snapshot: Snapshot
-
-        public var heroDetails: HeroDetails {
-          get {
-            return HeroDetails(snapshot: snapshot)
-          }
-          set {
-            snapshot += newValue.snapshot
-          }
-        }
-      }
-
-      public var asHuman: AsHuman? {
-        get {
-          if !AsHuman.possibleTypes.contains(__typename) { return nil }
-          return AsHuman(snapshot: snapshot)
-        }
-        set {
-          guard let newValue = newValue else { return }
-          snapshot = newValue.snapshot
-        }
-      }
-
-      public struct AsHuman: GraphQLSelectionSet {
-        public static let possibleTypes = ["Human"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          GraphQLField("height", type: .scalar(Double.self)),
-        ]
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
+            self.snapshot = snapshot
         }
 
-        public init(name: String, height: Double? = nil) {
-          self.init(snapshot: ["__typename": "Human", "name": name, "height": height])
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
         }
 
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
-
-        /// What this human calls themselves
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
-        }
-
-        /// Height in the preferred unit, default is meters
-        public var height: Double? {
-          get {
-            return snapshot["height"] as? Double
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "height")
-          }
-        }
-
-        public var fragments: Fragments {
-          get {
-            return Fragments(snapshot: snapshot)
-          }
-          set {
-            snapshot += newValue.snapshot
-          }
-        }
-
-        public struct Fragments {
-          public var snapshot: Snapshot
-
-          public var heroDetails: HeroDetails {
+        public var hero: Hero? {
             get {
-              return HeroDetails(snapshot: snapshot)
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
             }
             set {
-              snapshot += newValue.snapshot
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
             }
-          }
-        }
-      }
-
-      public var asDroid: AsDroid? {
-        get {
-          if !AsDroid.possibleTypes.contains(__typename) { return nil }
-          return AsDroid(snapshot: snapshot)
-        }
-        set {
-          guard let newValue = newValue else { return }
-          snapshot = newValue.snapshot
-        }
-      }
-
-      public struct AsDroid: GraphQLSelectionSet {
-        public static let possibleTypes = ["Droid"]
-
-        public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          GraphQLField("primaryFunction", type: .scalar(String.self)),
-        ]
-
-        public var snapshot: Snapshot
-
-        public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
         }
 
-        public init(name: String, primaryFunction: String? = nil) {
-          self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-        }
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
 
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
+            public static let selections: [GraphQLSelection] = [
+                GraphQLTypeCase(
+                    variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections],
+                    default: [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        ]
+                )
+            ]
 
-        /// What others call this droid
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
-        }
+            public var snapshot: Snapshot
 
-        /// This droid's primary function
-        public var primaryFunction: String? {
-          get {
-            return snapshot["primaryFunction"] as? String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "primaryFunction")
-          }
-        }
-
-        public var fragments: Fragments {
-          get {
-            return Fragments(snapshot: snapshot)
-          }
-          set {
-            snapshot += newValue.snapshot
-          }
-        }
-
-        public struct Fragments {
-          public var snapshot: Snapshot
-
-          public var heroDetails: HeroDetails {
-            get {
-              return HeroDetails(snapshot: snapshot)
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
             }
-            set {
-              snapshot += newValue.snapshot
+
+            public static func makeHuman(name: String, height: Double? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name, "height": height])
             }
-          }
+
+            public static func makeDroid(name: String, primaryFunction: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            public var fragments: Fragments {
+                get {
+                    return Fragments(snapshot: snapshot)
+                }
+                set {
+                    snapshot += newValue.snapshot
+                }
+            }
+
+            public struct Fragments {
+                public var snapshot: Snapshot
+
+                public var heroDetails: HeroDetails {
+                    get {
+                        return HeroDetails(snapshot: snapshot)
+                    }
+                    set {
+                        snapshot += newValue.snapshot
+                    }
+                }
+            }
+
+            public var asHuman: AsHuman? {
+                get {
+                    if !AsHuman.possibleTypes.contains(__typename) { return nil }
+                    return AsHuman(snapshot: snapshot)
+                }
+                set {
+                    guard let newValue = newValue else { return }
+                    snapshot = newValue.snapshot
+                }
+            }
+
+            public struct AsHuman: GraphQLSelectionSet {
+                public static let possibleTypes = ["Human"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("height", type: .scalar(Double.self)),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public init(name: String, height: Double? = nil) {
+                    self.init(snapshot: ["__typename": "Human", "name": name, "height": height])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// What this human calls themselves
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+
+                /// Height in the preferred unit, default is meters
+                public var height: Double? {
+                    get {
+                        return snapshot["height"] as? Double
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "height")
+                    }
+                }
+
+                public var fragments: Fragments {
+                    get {
+                        return Fragments(snapshot: snapshot)
+                    }
+                    set {
+                        snapshot += newValue.snapshot
+                    }
+                }
+
+                public struct Fragments {
+                    public var snapshot: Snapshot
+
+                    public var heroDetails: HeroDetails {
+                        get {
+                            return HeroDetails(snapshot: snapshot)
+                        }
+                        set {
+                            snapshot += newValue.snapshot
+                        }
+                    }
+                }
+            }
+
+            public var asDroid: AsDroid? {
+                get {
+                    if !AsDroid.possibleTypes.contains(__typename) { return nil }
+                    return AsDroid(snapshot: snapshot)
+                }
+                set {
+                    guard let newValue = newValue else { return }
+                    snapshot = newValue.snapshot
+                }
+            }
+
+            public struct AsDroid: GraphQLSelectionSet {
+                public static let possibleTypes = ["Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("primaryFunction", type: .scalar(String.self)),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public init(name: String, primaryFunction: String? = nil) {
+                    self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// What others call this droid
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+
+                /// This droid's primary function
+                public var primaryFunction: String? {
+                    get {
+                        return snapshot["primaryFunction"] as? String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "primaryFunction")
+                    }
+                }
+
+                public var fragments: Fragments {
+                    get {
+                        return Fragments(snapshot: snapshot)
+                    }
+                    set {
+                        snapshot += newValue.snapshot
+                    }
+                }
+
+                public struct Fragments {
+                    public var snapshot: Snapshot
+
+                    public var heroDetails: HeroDetails {
+                        get {
+                            return HeroDetails(snapshot: snapshot)
+                        }
+                        set {
+                            snapshot += newValue.snapshot
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 public final class DroidDetailsWithFragmentQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query DroidDetailsWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...DroidDetails\n  }\n}"
 
-  public static var requestString: String { return operationString.appending(DroidDetails.fragmentString) }
+    public static var requestString: String { return operationString.appending(DroidDetails.fragmentString) }
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLTypeCase(
-          variants: ["Droid": AsDroid.selections],
-          default: [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          ]
-        )
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman() -> Hero {
-        return Hero(snapshot: ["__typename": "Human"])
-      }
-
-      public static func makeDroid(name: String, primaryFunction: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      public var fragments: Fragments {
-        get {
-          return Fragments(snapshot: snapshot)
-        }
-        set {
-          snapshot += newValue.snapshot
-        }
-      }
-
-      public struct Fragments {
-        public var snapshot: Snapshot
-
-        public var droidDetails: DroidDetails? {
-          get {
-            if !DroidDetails.possibleTypes.contains(snapshot["__typename"]! as! String) { return nil }
-            return DroidDetails(snapshot: snapshot)
-          }
-          set {
-            guard let newValue = newValue else { return }
-            snapshot += newValue.snapshot
-          }
-        }
-      }
-
-      public var asDroid: AsDroid? {
-        get {
-          if !AsDroid.possibleTypes.contains(__typename) { return nil }
-          return AsDroid(snapshot: snapshot)
-        }
-        set {
-          guard let newValue = newValue else { return }
-          snapshot = newValue.snapshot
-        }
-      }
-
-      public struct AsDroid: GraphQLSelectionSet {
-        public static let possibleTypes = ["Droid"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          GraphQLField("primaryFunction", type: .scalar(String.self)),
-        ]
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
+            self.snapshot = snapshot
         }
 
-        public init(name: String, primaryFunction: String? = nil) {
-          self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
         }
 
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
-
-        /// What others call this droid
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
-        }
-
-        /// This droid's primary function
-        public var primaryFunction: String? {
-          get {
-            return snapshot["primaryFunction"] as? String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "primaryFunction")
-          }
-        }
-
-        public var fragments: Fragments {
-          get {
-            return Fragments(snapshot: snapshot)
-          }
-          set {
-            snapshot += newValue.snapshot
-          }
-        }
-
-        public struct Fragments {
-          public var snapshot: Snapshot
-
-          public var droidDetails: DroidDetails {
+        public var hero: Hero? {
             get {
-              return DroidDetails(snapshot: snapshot)
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
             }
             set {
-              snapshot += newValue.snapshot
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
             }
-          }
         }
-      }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLTypeCase(
+                    variants: ["Droid": AsDroid.selections],
+                    default: [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        ]
+                )
+            ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman() -> Hero {
+                return Hero(snapshot: ["__typename": "Human"])
+            }
+
+            public static func makeDroid(name: String, primaryFunction: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            public var fragments: Fragments {
+                get {
+                    return Fragments(snapshot: snapshot)
+                }
+                set {
+                    snapshot += newValue.snapshot
+                }
+            }
+
+            public struct Fragments {
+                public var snapshot: Snapshot
+
+                public var droidDetails: DroidDetails? {
+                    get {
+                        if !DroidDetails.possibleTypes.contains(snapshot["__typename"]! as! String) { return nil }
+                        return DroidDetails(snapshot: snapshot)
+                    }
+                    set {
+                        guard let newValue = newValue else { return }
+                        snapshot += newValue.snapshot
+                    }
+                }
+            }
+
+            public var asDroid: AsDroid? {
+                get {
+                    if !AsDroid.possibleTypes.contains(__typename) { return nil }
+                    return AsDroid(snapshot: snapshot)
+                }
+                set {
+                    guard let newValue = newValue else { return }
+                    snapshot = newValue.snapshot
+                }
+            }
+
+            public struct AsDroid: GraphQLSelectionSet {
+                public static let possibleTypes = ["Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("primaryFunction", type: .scalar(String.self)),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public init(name: String, primaryFunction: String? = nil) {
+                    self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// What others call this droid
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+
+                /// This droid's primary function
+                public var primaryFunction: String? {
+                    get {
+                        return snapshot["primaryFunction"] as? String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "primaryFunction")
+                    }
+                }
+
+                public var fragments: Fragments {
+                    get {
+                        return Fragments(snapshot: snapshot)
+                    }
+                    set {
+                        snapshot += newValue.snapshot
+                    }
+                }
+
+                public struct Fragments {
+                    public var snapshot: Snapshot
+
+                    public var droidDetails: DroidDetails {
+                        get {
+                            return DroidDetails(snapshot: snapshot)
+                        }
+                        set {
+                            snapshot += newValue.snapshot
+                        }
+                    }
+                }
+            }
+        }
     }
-  }
 }
 
 public final class HeroFriendsOfFriendsNamesQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroFriendsOfFriendsNames($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    friends {\n      __typename\n      id\n      friends {\n        __typename\n        name\n      }\n    }\n  }\n}"
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("friends", type: .list(.object(Friend.selections))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public static func makeDroid(friends: [Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The friends of the character, or an empty list if they have none
-      public var friends: [Friend?]? {
-        get {
-          return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-        }
-        set {
-          snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-        }
-      }
-
-      public struct Friend: GraphQLSelectionSet {
-        public static let possibleTypes = ["Human", "Droid"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
-          GraphQLField("friends", type: .list(.object(Friend.selections))),
-        ]
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
-        }
-
-        public static func makeHuman(id: GraphQLID, friends: [Friend?]? = nil) -> Friend {
-          return Friend(snapshot: ["__typename": "Human", "id": id, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-        }
-
-        public static func makeDroid(id: GraphQLID, friends: [Friend?]? = nil) -> Friend {
-          return Friend(snapshot: ["__typename": "Droid", "id": id, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-        }
-
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
-
-        /// The ID of the character
-        public var id: GraphQLID {
-          get {
-            return snapshot["id"]! as! GraphQLID
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "id")
-          }
-        }
-
-        /// The friends of the character, or an empty list if they have none
-        public var friends: [Friend?]? {
-          get {
-            return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-          }
-          set {
-            snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-          }
-        }
-
-        public struct Friend: GraphQLSelectionSet {
-          public static let possibleTypes = ["Human", "Droid"]
-
-          public static let selections: [GraphQLSelection] = [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          ]
-
-          public var snapshot: Snapshot
-
-          public init(snapshot: Snapshot) {
             self.snapshot = snapshot
-          }
-
-          public static func makeHuman(name: String) -> Friend {
-            return Friend(snapshot: ["__typename": "Human", "name": name])
-          }
-
-          public static func makeDroid(name: String) -> Friend {
-            return Friend(snapshot: ["__typename": "Droid", "name": name])
-          }
-
-          public var __typename: String {
-            get {
-              return snapshot["__typename"]! as! String
-            }
-            set {
-              snapshot.updateValue(newValue, forKey: "__typename")
-            }
-          }
-
-          /// The name of the character
-          public var name: String {
-            get {
-              return snapshot["name"]! as! String
-            }
-            set {
-              snapshot.updateValue(newValue, forKey: "name")
-            }
-          }
         }
-      }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("friends", type: .list(.object(Friend.selections))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public static func makeDroid(friends: [Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The friends of the character, or an empty list if they have none
+            public var friends: [Friend?]? {
+                get {
+                    return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+                }
+                set {
+                    snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+                }
+            }
+
+            public struct Friend: GraphQLSelectionSet {
+                public static let possibleTypes = ["Human", "Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+                    GraphQLField("friends", type: .list(.object(Friend.selections))),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public static func makeHuman(id: GraphQLID, friends: [Friend?]? = nil) -> Friend {
+                    return Friend(snapshot: ["__typename": "Human", "id": id, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+                }
+
+                public static func makeDroid(id: GraphQLID, friends: [Friend?]? = nil) -> Friend {
+                    return Friend(snapshot: ["__typename": "Droid", "id": id, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// The ID of the character
+                public var id: GraphQLID {
+                    get {
+                        return snapshot["id"]! as! GraphQLID
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "id")
+                    }
+                }
+
+                /// The friends of the character, or an empty list if they have none
+                public var friends: [Friend?]? {
+                    get {
+                        return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+                    }
+                    set {
+                        snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+                    }
+                }
+
+                public struct Friend: GraphQLSelectionSet {
+                    public static let possibleTypes = ["Human", "Droid"]
+
+                    public static let selections: [GraphQLSelection] = [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        ]
+
+                    public var snapshot: Snapshot
+
+                    public init(snapshot: Snapshot) {
+                        self.snapshot = snapshot
+                    }
+
+                    public static func makeHuman(name: String) -> Friend {
+                        return Friend(snapshot: ["__typename": "Human", "name": name])
+                    }
+
+                    public static func makeDroid(name: String) -> Friend {
+                        return Friend(snapshot: ["__typename": "Droid", "name": name])
+                    }
+
+                    public var __typename: String {
+                        get {
+                            return snapshot["__typename"]! as! String
+                        }
+                        set {
+                            snapshot.updateValue(newValue, forKey: "__typename")
+                        }
+                    }
+
+                    /// The name of the character
+                    public var name: String {
+                        get {
+                            return snapshot["name"]! as! String
+                        }
+                        set {
+                            snapshot.updateValue(newValue, forKey: "name")
+                        }
+                    }
+                }
+            }
+        }
     }
-  }
 }
 
 public final class HeroNameQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroName($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    optionalString\n  }\n}"
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                GraphQLField("optionalString", type: .scalar(String.self)),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String, optionalString: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name, "optionalString": optionalString])
+            }
+
+            public static func makeDroid(name: String, optionalString: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name, "optionalString": optionalString])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            /// An optional string value
+            public var optionalString: String? {
+                get {
+                    return snapshot["optionalString"] as? String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "optionalString")
+                }
+            }
+        }
     }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        GraphQLField("optionalString", type: .scalar(String.self)),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String, optionalString: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name, "optionalString": optionalString])
-      }
-
-      public static func makeDroid(name: String, optionalString: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name, "optionalString": optionalString])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      /// An optional string value
-      public var optionalString: String? {
-        get {
-          return snapshot["optionalString"] as? String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "optionalString")
-        }
-      }
-    }
-  }
 }
 
 public final class HeroNameWithIdQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroNameWithID($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    id\n    name\n  }\n}"
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(id: GraphQLID, name: String) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "id": id, "name": name])
+            }
+
+            public static func makeDroid(id: GraphQLID, name: String) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "id": id, "name": name])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The ID of the character
+            public var id: GraphQLID {
+                get {
+                    return snapshot["id"]! as! GraphQLID
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "id")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+        }
     }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(id: GraphQLID, name: String) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "id": id, "name": name])
-      }
-
-      public static func makeDroid(id: GraphQLID, name: String) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "id": id, "name": name])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The ID of the character
-      public var id: GraphQLID {
-        get {
-          return snapshot["id"]! as! GraphQLID
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "id")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-    }
-  }
 }
 
 public final class HeroNameWithFragmentQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroNameWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...CharacterName\n  }\n}"
 
-  public static var requestString: String { return operationString.appending(CharacterName.fragmentString) }
+    public static var requestString: String { return operationString.appending(CharacterName.fragmentString) }
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name])
-      }
-
-      public static func makeDroid(name: String) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      public var fragments: Fragments {
-        get {
-          return Fragments(snapshot: snapshot)
-        }
-        set {
-          snapshot += newValue.snapshot
-        }
-      }
-
-      public struct Fragments {
         public var snapshot: Snapshot
 
-        public var characterName: CharacterName {
-          get {
-            return CharacterName(snapshot: snapshot)
-          }
-          set {
-            snapshot += newValue.snapshot
-          }
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
         }
-      }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name])
+            }
+
+            public static func makeDroid(name: String) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            public var fragments: Fragments {
+                get {
+                    return Fragments(snapshot: snapshot)
+                }
+                set {
+                    snapshot += newValue.snapshot
+                }
+            }
+
+            public struct Fragments {
+                public var snapshot: Snapshot
+
+                public var characterName: CharacterName {
+                    get {
+                        return CharacterName(snapshot: snapshot)
+                    }
+                    set {
+                        snapshot += newValue.snapshot
+                    }
+                }
+            }
+        }
     }
-  }
 }
 
 public final class HeroNameWithFragmentAndIdQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroNameWithFragmentAndID($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    id\n    ...CharacterName\n  }\n}"
 
-  public static var requestString: String { return operationString.appending(CharacterName.fragmentString) }
+    public static var requestString: String { return operationString.appending(CharacterName.fragmentString) }
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(id: GraphQLID, name: String) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "id": id, "name": name])
-      }
-
-      public static func makeDroid(id: GraphQLID, name: String) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "id": id, "name": name])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The ID of the character
-      public var id: GraphQLID {
-        get {
-          return snapshot["id"]! as! GraphQLID
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "id")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      public var fragments: Fragments {
-        get {
-          return Fragments(snapshot: snapshot)
-        }
-        set {
-          snapshot += newValue.snapshot
-        }
-      }
-
-      public struct Fragments {
         public var snapshot: Snapshot
 
-        public var characterName: CharacterName {
-          get {
-            return CharacterName(snapshot: snapshot)
-          }
-          set {
-            snapshot += newValue.snapshot
-          }
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
         }
-      }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(id: GraphQLID, name: String) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "id": id, "name": name])
+            }
+
+            public static func makeDroid(id: GraphQLID, name: String) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "id": id, "name": name])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The ID of the character
+            public var id: GraphQLID {
+                get {
+                    return snapshot["id"]! as! GraphQLID
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "id")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            public var fragments: Fragments {
+                get {
+                    return Fragments(snapshot: snapshot)
+                }
+                set {
+                    snapshot += newValue.snapshot
+                }
+            }
+
+            public struct Fragments {
+                public var snapshot: Snapshot
+
+                public var characterName: CharacterName {
+                    get {
+                        return CharacterName(snapshot: snapshot)
+                    }
+                    set {
+                        snapshot += newValue.snapshot
+                    }
+                }
+            }
+        }
     }
-  }
 }
 
 public final class HeroNameAndAppearsInWithFragmentQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroNameAndAppearsInWithFragment($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ...CharacterNameAndAppearsIn\n  }\n}"
 
-  public static var requestString: String { return operationString.appending(CharacterNameAndAppearsIn.fragmentString) }
+    public static var requestString: String { return operationString.appending(CharacterNameAndAppearsIn.fragmentString) }
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String, appearsIn: [Episode?]) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name, "appearsIn": appearsIn])
-      }
-
-      public static func makeDroid(name: String, appearsIn: [Episode?]) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name, "appearsIn": appearsIn])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      /// The movies this character appears in
-      public var appearsIn: [Episode?] {
-        get {
-          return snapshot["appearsIn"]! as! [Episode?]
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "appearsIn")
-        }
-      }
-
-      public var fragments: Fragments {
-        get {
-          return Fragments(snapshot: snapshot)
-        }
-        set {
-          snapshot += newValue.snapshot
-        }
-      }
-
-      public struct Fragments {
         public var snapshot: Snapshot
 
-        public var characterNameAndAppearsIn: CharacterNameAndAppearsIn {
-          get {
-            return CharacterNameAndAppearsIn(snapshot: snapshot)
-          }
-          set {
-            snapshot += newValue.snapshot
-          }
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
         }
-      }
+
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String, appearsIn: [Episode?]) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name, "appearsIn": appearsIn])
+            }
+
+            public static func makeDroid(name: String, appearsIn: [Episode?]) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name, "appearsIn": appearsIn])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            /// The movies this character appears in
+            public var appearsIn: [Episode?] {
+                get {
+                    return snapshot["appearsIn"]! as! [Episode?]
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "appearsIn")
+                }
+            }
+
+            public var fragments: Fragments {
+                get {
+                    return Fragments(snapshot: snapshot)
+                }
+                set {
+                    snapshot += newValue.snapshot
+                }
+            }
+
+            public struct Fragments {
+                public var snapshot: Snapshot
+
+                public var characterNameAndAppearsIn: CharacterNameAndAppearsIn {
+                    get {
+                        return CharacterNameAndAppearsIn(snapshot: snapshot)
+                    }
+                    set {
+                        snapshot += newValue.snapshot
+                    }
+                }
+            }
+        }
     }
-  }
 }
 
 public final class HeroParentTypeDependentFieldQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroParentTypeDependentField($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    ... on Human {\n      friends {\n        __typename\n        name\n        ... on Human {\n          height(unit: FOOT)\n        }\n      }\n    }\n    ... on Droid {\n      friends {\n        __typename\n        name\n        ... on Human {\n          height(unit: METER)\n        }\n      }\n    }\n  }\n}"
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLTypeCase(
-          variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections],
-          default: [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-            GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          ]
-        )
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String, friends: [AsHuman.Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public static func makeDroid(name: String, friends: [AsDroid.Friend?]? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      public var asHuman: AsHuman? {
-        get {
-          if !AsHuman.possibleTypes.contains(__typename) { return nil }
-          return AsHuman(snapshot: snapshot)
-        }
-        set {
-          guard let newValue = newValue else { return }
-          snapshot = newValue.snapshot
-        }
-      }
-
-      public struct AsHuman: GraphQLSelectionSet {
-        public static let possibleTypes = ["Human"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          GraphQLField("friends", type: .list(.object(Friend.selections))),
-        ]
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
-        }
-
-        public init(name: String, friends: [Friend?]? = nil) {
-          self.init(snapshot: ["__typename": "Human", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-        }
-
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
-
-        /// What this human calls themselves
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
-        }
-
-        /// This human's friends, or an empty list if they have none
-        public var friends: [Friend?]? {
-          get {
-            return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-          }
-          set {
-            snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-          }
-        }
-
-        public struct Friend: GraphQLSelectionSet {
-          public static let possibleTypes = ["Human", "Droid"]
-
-          public static let selections: [GraphQLSelection] = [
-            GraphQLTypeCase(
-              variants: ["Human": AsHuman.selections],
-              default: [
-                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-                GraphQLField("name", type: .nonNull(.scalar(String.self))),
-              ]
-            )
-          ]
-
-          public var snapshot: Snapshot
-
-          public init(snapshot: Snapshot) {
             self.snapshot = snapshot
-          }
+        }
 
-          public static func makeDroid(name: String) -> Friend {
-            return Friend(snapshot: ["__typename": "Droid", "name": name])
-          }
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+        }
 
-          public static func makeHuman(name: String, height: Double? = nil) -> Friend {
-            return Friend(snapshot: ["__typename": "Human", "name": name, "height": height])
-          }
-
-          public var __typename: String {
+        public var hero: Hero? {
             get {
-              return snapshot["__typename"]! as! String
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
             }
             set {
-              snapshot.updateValue(newValue, forKey: "__typename")
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
             }
-          }
+        }
 
-          /// The name of the character
-          public var name: String {
-            get {
-              return snapshot["name"]! as! String
-            }
-            set {
-              snapshot.updateValue(newValue, forKey: "name")
-            }
-          }
-
-          public var asHuman: AsHuman? {
-            get {
-              if !AsHuman.possibleTypes.contains(__typename) { return nil }
-              return AsHuman(snapshot: snapshot)
-            }
-            set {
-              guard let newValue = newValue else { return }
-              snapshot = newValue.snapshot
-            }
-          }
-
-          public struct AsHuman: GraphQLSelectionSet {
-            public static let possibleTypes = ["Human"]
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
 
             public static let selections: [GraphQLSelection] = [
-              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-              GraphQLField("name", type: .nonNull(.scalar(String.self))),
-              GraphQLField("height", arguments: ["unit": "FOOT"], type: .scalar(Double.self)),
+                GraphQLTypeCase(
+                    variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections],
+                    default: [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                        ]
+                )
             ]
 
             public var snapshot: Snapshot
 
             public init(snapshot: Snapshot) {
-              self.snapshot = snapshot
+                self.snapshot = snapshot
             }
 
-            public init(name: String, height: Double? = nil) {
-              self.init(snapshot: ["__typename": "Human", "name": name, "height": height])
+            public static func makeHuman(name: String, friends: [AsHuman.Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
             }
 
-            public var __typename: String {
-              get {
-                return snapshot["__typename"]! as! String
-              }
-              set {
-                snapshot.updateValue(newValue, forKey: "__typename")
-              }
-            }
-
-            /// What this human calls themselves
-            public var name: String {
-              get {
-                return snapshot["name"]! as! String
-              }
-              set {
-                snapshot.updateValue(newValue, forKey: "name")
-              }
-            }
-
-            /// Height in the preferred unit, default is meters
-            public var height: Double? {
-              get {
-                return snapshot["height"] as? Double
-              }
-              set {
-                snapshot.updateValue(newValue, forKey: "height")
-              }
-            }
-          }
-        }
-      }
-
-      public var asDroid: AsDroid? {
-        get {
-          if !AsDroid.possibleTypes.contains(__typename) { return nil }
-          return AsDroid(snapshot: snapshot)
-        }
-        set {
-          guard let newValue = newValue else { return }
-          snapshot = newValue.snapshot
-        }
-      }
-
-      public struct AsDroid: GraphQLSelectionSet {
-        public static let possibleTypes = ["Droid"]
-
-        public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("name", type: .nonNull(.scalar(String.self))),
-          GraphQLField("friends", type: .list(.object(Friend.selections))),
-        ]
-
-        public var snapshot: Snapshot
-
-        public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
-        }
-
-        public init(name: String, friends: [Friend?]? = nil) {
-          self.init(snapshot: ["__typename": "Droid", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-        }
-
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
-
-        /// What others call this droid
-        public var name: String {
-          get {
-            return snapshot["name"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "name")
-          }
-        }
-
-        /// This droid's friends, or an empty list if they have none
-        public var friends: [Friend?]? {
-          get {
-            return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-          }
-          set {
-            snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-          }
-        }
-
-        public struct Friend: GraphQLSelectionSet {
-          public static let possibleTypes = ["Human", "Droid"]
-
-          public static let selections: [GraphQLSelection] = [
-            GraphQLTypeCase(
-              variants: ["Human": AsHuman.selections],
-              default: [
-                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-                GraphQLField("name", type: .nonNull(.scalar(String.self))),
-              ]
-            )
-          ]
-
-          public var snapshot: Snapshot
-
-          public init(snapshot: Snapshot) {
-            self.snapshot = snapshot
-          }
-
-          public static func makeDroid(name: String) -> Friend {
-            return Friend(snapshot: ["__typename": "Droid", "name": name])
-          }
-
-          public static func makeHuman(name: String, height: Double? = nil) -> Friend {
-            return Friend(snapshot: ["__typename": "Human", "name": name, "height": height])
-          }
-
-          public var __typename: String {
-            get {
-              return snapshot["__typename"]! as! String
-            }
-            set {
-              snapshot.updateValue(newValue, forKey: "__typename")
-            }
-          }
-
-          /// The name of the character
-          public var name: String {
-            get {
-              return snapshot["name"]! as! String
-            }
-            set {
-              snapshot.updateValue(newValue, forKey: "name")
-            }
-          }
-
-          public var asHuman: AsHuman? {
-            get {
-              if !AsHuman.possibleTypes.contains(__typename) { return nil }
-              return AsHuman(snapshot: snapshot)
-            }
-            set {
-              guard let newValue = newValue else { return }
-              snapshot = newValue.snapshot
-            }
-          }
-
-          public struct AsHuman: GraphQLSelectionSet {
-            public static let possibleTypes = ["Human"]
-
-            public static let selections: [GraphQLSelection] = [
-              GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-              GraphQLField("name", type: .nonNull(.scalar(String.self))),
-              GraphQLField("height", arguments: ["unit": "METER"], type: .scalar(Double.self)),
-            ]
-
-            public var snapshot: Snapshot
-
-            public init(snapshot: Snapshot) {
-              self.snapshot = snapshot
-            }
-
-            public init(name: String, height: Double? = nil) {
-              self.init(snapshot: ["__typename": "Human", "name": name, "height": height])
+            public static func makeDroid(name: String, friends: [AsDroid.Friend?]? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
             }
 
             public var __typename: String {
-              get {
-                return snapshot["__typename"]! as! String
-              }
-              set {
-                snapshot.updateValue(newValue, forKey: "__typename")
-              }
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
             }
 
-            /// What this human calls themselves
+            /// The name of the character
             public var name: String {
-              get {
-                return snapshot["name"]! as! String
-              }
-              set {
-                snapshot.updateValue(newValue, forKey: "name")
-              }
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
             }
 
-            /// Height in the preferred unit, default is meters
-            public var height: Double? {
-              get {
-                return snapshot["height"] as? Double
-              }
-              set {
-                snapshot.updateValue(newValue, forKey: "height")
-              }
+            public var asHuman: AsHuman? {
+                get {
+                    if !AsHuman.possibleTypes.contains(__typename) { return nil }
+                    return AsHuman(snapshot: snapshot)
+                }
+                set {
+                    guard let newValue = newValue else { return }
+                    snapshot = newValue.snapshot
+                }
             }
-          }
+
+            public struct AsHuman: GraphQLSelectionSet {
+                public static let possibleTypes = ["Human"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("friends", type: .list(.object(Friend.selections))),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public init(name: String, friends: [Friend?]? = nil) {
+                    self.init(snapshot: ["__typename": "Human", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// What this human calls themselves
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+
+                /// This human's friends, or an empty list if they have none
+                public var friends: [Friend?]? {
+                    get {
+                        return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+                    }
+                    set {
+                        snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+                    }
+                }
+
+                public struct Friend: GraphQLSelectionSet {
+                    public static let possibleTypes = ["Human", "Droid"]
+
+                    public static let selections: [GraphQLSelection] = [
+                        GraphQLTypeCase(
+                            variants: ["Human": AsHuman.selections],
+                            default: [
+                                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                                ]
+                        )
+                    ]
+
+                    public var snapshot: Snapshot
+
+                    public init(snapshot: Snapshot) {
+                        self.snapshot = snapshot
+                    }
+
+                    public static func makeDroid(name: String) -> Friend {
+                        return Friend(snapshot: ["__typename": "Droid", "name": name])
+                    }
+
+                    public static func makeHuman(name: String, height: Double? = nil) -> Friend {
+                        return Friend(snapshot: ["__typename": "Human", "name": name, "height": height])
+                    }
+
+                    public var __typename: String {
+                        get {
+                            return snapshot["__typename"]! as! String
+                        }
+                        set {
+                            snapshot.updateValue(newValue, forKey: "__typename")
+                        }
+                    }
+
+                    /// The name of the character
+                    public var name: String {
+                        get {
+                            return snapshot["name"]! as! String
+                        }
+                        set {
+                            snapshot.updateValue(newValue, forKey: "name")
+                        }
+                    }
+
+                    public var asHuman: AsHuman? {
+                        get {
+                            if !AsHuman.possibleTypes.contains(__typename) { return nil }
+                            return AsHuman(snapshot: snapshot)
+                        }
+                        set {
+                            guard let newValue = newValue else { return }
+                            snapshot = newValue.snapshot
+                        }
+                    }
+
+                    public struct AsHuman: GraphQLSelectionSet {
+                        public static let possibleTypes = ["Human"]
+
+                        public static let selections: [GraphQLSelection] = [
+                            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                            GraphQLField("height", arguments: ["unit": "FOOT"], type: .scalar(Double.self)),
+                            ]
+
+                        public var snapshot: Snapshot
+
+                        public init(snapshot: Snapshot) {
+                            self.snapshot = snapshot
+                        }
+
+                        public init(name: String, height: Double? = nil) {
+                            self.init(snapshot: ["__typename": "Human", "name": name, "height": height])
+                        }
+
+                        public var __typename: String {
+                            get {
+                                return snapshot["__typename"]! as! String
+                            }
+                            set {
+                                snapshot.updateValue(newValue, forKey: "__typename")
+                            }
+                        }
+
+                        /// What this human calls themselves
+                        public var name: String {
+                            get {
+                                return snapshot["name"]! as! String
+                            }
+                            set {
+                                snapshot.updateValue(newValue, forKey: "name")
+                            }
+                        }
+
+                        /// Height in the preferred unit, default is meters
+                        public var height: Double? {
+                            get {
+                                return snapshot["height"] as? Double
+                            }
+                            set {
+                                snapshot.updateValue(newValue, forKey: "height")
+                            }
+                        }
+                    }
+                }
+            }
+
+            public var asDroid: AsDroid? {
+                get {
+                    if !AsDroid.possibleTypes.contains(__typename) { return nil }
+                    return AsDroid(snapshot: snapshot)
+                }
+                set {
+                    guard let newValue = newValue else { return }
+                    snapshot = newValue.snapshot
+                }
+            }
+
+            public struct AsDroid: GraphQLSelectionSet {
+                public static let possibleTypes = ["Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("friends", type: .list(.object(Friend.selections))),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public init(name: String, friends: [Friend?]? = nil) {
+                    self.init(snapshot: ["__typename": "Droid", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// What others call this droid
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+
+                /// This droid's friends, or an empty list if they have none
+                public var friends: [Friend?]? {
+                    get {
+                        return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+                    }
+                    set {
+                        snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+                    }
+                }
+
+                public struct Friend: GraphQLSelectionSet {
+                    public static let possibleTypes = ["Human", "Droid"]
+
+                    public static let selections: [GraphQLSelection] = [
+                        GraphQLTypeCase(
+                            variants: ["Human": AsHuman.selections],
+                            default: [
+                                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                                ]
+                        )
+                    ]
+
+                    public var snapshot: Snapshot
+
+                    public init(snapshot: Snapshot) {
+                        self.snapshot = snapshot
+                    }
+
+                    public static func makeDroid(name: String) -> Friend {
+                        return Friend(snapshot: ["__typename": "Droid", "name": name])
+                    }
+
+                    public static func makeHuman(name: String, height: Double? = nil) -> Friend {
+                        return Friend(snapshot: ["__typename": "Human", "name": name, "height": height])
+                    }
+
+                    public var __typename: String {
+                        get {
+                            return snapshot["__typename"]! as! String
+                        }
+                        set {
+                            snapshot.updateValue(newValue, forKey: "__typename")
+                        }
+                    }
+
+                    /// The name of the character
+                    public var name: String {
+                        get {
+                            return snapshot["name"]! as! String
+                        }
+                        set {
+                            snapshot.updateValue(newValue, forKey: "name")
+                        }
+                    }
+
+                    public var asHuman: AsHuman? {
+                        get {
+                            if !AsHuman.possibleTypes.contains(__typename) { return nil }
+                            return AsHuman(snapshot: snapshot)
+                        }
+                        set {
+                            guard let newValue = newValue else { return }
+                            snapshot = newValue.snapshot
+                        }
+                    }
+
+                    public struct AsHuman: GraphQLSelectionSet {
+                        public static let possibleTypes = ["Human"]
+
+                        public static let selections: [GraphQLSelection] = [
+                            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                            GraphQLField("height", arguments: ["unit": "METER"], type: .scalar(Double.self)),
+                            ]
+
+                        public var snapshot: Snapshot
+
+                        public init(snapshot: Snapshot) {
+                            self.snapshot = snapshot
+                        }
+
+                        public init(name: String, height: Double? = nil) {
+                            self.init(snapshot: ["__typename": "Human", "name": name, "height": height])
+                        }
+
+                        public var __typename: String {
+                            get {
+                                return snapshot["__typename"]! as! String
+                            }
+                            set {
+                                snapshot.updateValue(newValue, forKey: "__typename")
+                            }
+                        }
+
+                        /// What this human calls themselves
+                        public var name: String {
+                            get {
+                                return snapshot["name"]! as! String
+                            }
+                            set {
+                                snapshot.updateValue(newValue, forKey: "name")
+                            }
+                        }
+
+                        /// Height in the preferred unit, default is meters
+                        public var height: Double? {
+                            get {
+                                return snapshot["height"] as? Double
+                            }
+                            set {
+                                snapshot.updateValue(newValue, forKey: "height")
+                            }
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
 public final class HeroTypeDependentAliasedFieldQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query HeroTypeDependentAliasedField($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    ... on Human {\n      property: homePlanet\n    }\n    ... on Droid {\n      property: primaryFunction\n    }\n  }\n}"
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(hero: Hero? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLTypeCase(
-          variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections],
-          default: [
-            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          ]
-        )
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(property: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "property": property])
-      }
-
-      public static func makeDroid(property: String? = nil) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "property": property])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      public var asHuman: AsHuman? {
-        get {
-          if !AsHuman.possibleTypes.contains(__typename) { return nil }
-          return AsHuman(snapshot: snapshot)
-        }
-        set {
-          guard let newValue = newValue else { return }
-          snapshot = newValue.snapshot
-        }
-      }
-
-      public struct AsHuman: GraphQLSelectionSet {
-        public static let possibleTypes = ["Human"]
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
 
         public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("homePlanet", alias: "property", type: .scalar(String.self)),
-        ]
+            GraphQLField("hero", arguments: ["episode": GraphQLVariable("episode")], type: .object(Hero.selections)),
+            ]
 
         public var snapshot: Snapshot
 
         public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
+            self.snapshot = snapshot
         }
 
-        public init(property: String? = nil) {
-          self.init(snapshot: ["__typename": "Human", "property": property])
+        public init(hero: Hero? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }])
         }
 
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
         }
 
-        /// The home planet of the human, or null if unknown
-        public var property: String? {
-          get {
-            return snapshot["property"] as? String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "property")
-          }
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLTypeCase(
+                    variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections],
+                    default: [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        ]
+                )
+            ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(property: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "property": property])
+            }
+
+            public static func makeDroid(property: String? = nil) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "property": property])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            public var asHuman: AsHuman? {
+                get {
+                    if !AsHuman.possibleTypes.contains(__typename) { return nil }
+                    return AsHuman(snapshot: snapshot)
+                }
+                set {
+                    guard let newValue = newValue else { return }
+                    snapshot = newValue.snapshot
+                }
+            }
+
+            public struct AsHuman: GraphQLSelectionSet {
+                public static let possibleTypes = ["Human"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("homePlanet", alias: "property", type: .scalar(String.self)),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public init(property: String? = nil) {
+                    self.init(snapshot: ["__typename": "Human", "property": property])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// The home planet of the human, or null if unknown
+                public var property: String? {
+                    get {
+                        return snapshot["property"] as? String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "property")
+                    }
+                }
+            }
+
+            public var asDroid: AsDroid? {
+                get {
+                    if !AsDroid.possibleTypes.contains(__typename) { return nil }
+                    return AsDroid(snapshot: snapshot)
+                }
+                set {
+                    guard let newValue = newValue else { return }
+                    snapshot = newValue.snapshot
+                }
+            }
+
+            public struct AsDroid: GraphQLSelectionSet {
+                public static let possibleTypes = ["Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("primaryFunction", alias: "property", type: .scalar(String.self)),
+                    ]
+
+                public var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public init(property: String? = nil) {
+                    self.init(snapshot: ["__typename": "Droid", "property": property])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// This droid's primary function
+                public var property: String? {
+                    get {
+                        return snapshot["property"] as? String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "property")
+                    }
+                }
+            }
         }
-      }
-
-      public var asDroid: AsDroid? {
-        get {
-          if !AsDroid.possibleTypes.contains(__typename) { return nil }
-          return AsDroid(snapshot: snapshot)
-        }
-        set {
-          guard let newValue = newValue else { return }
-          snapshot = newValue.snapshot
-        }
-      }
-
-      public struct AsDroid: GraphQLSelectionSet {
-        public static let possibleTypes = ["Droid"]
-
-        public static let selections: [GraphQLSelection] = [
-          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-          GraphQLField("primaryFunction", alias: "property", type: .scalar(String.self)),
-        ]
-
-        public var snapshot: Snapshot
-
-        public init(snapshot: Snapshot) {
-          self.snapshot = snapshot
-        }
-
-        public init(property: String? = nil) {
-          self.init(snapshot: ["__typename": "Droid", "property": property])
-        }
-
-        public var __typename: String {
-          get {
-            return snapshot["__typename"]! as! String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "__typename")
-          }
-        }
-
-        /// This droid's primary function
-        public var property: String? {
-          get {
-            return snapshot["property"] as? String
-          }
-          set {
-            snapshot.updateValue(newValue, forKey: "property")
-          }
-        }
-      }
     }
-  }
 }
 
 public final class HumanQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query Human($id: ID!) {\n  human(id: $id) {\n    __typename\n    name\n    mass\n  }\n}"
 
-  public var id: GraphQLID
+    public var id: GraphQLID
 
-  public init(id: GraphQLID) {
-    self.id = id
-  }
-
-  public var variables: GraphQLMap? {
-    return ["id": id]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("human", arguments: ["id": GraphQLVariable("id")], type: .object(Human.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(id: GraphQLID) {
+        self.id = id
     }
 
-    public init(human: Human? = nil) {
-      self.init(snapshot: ["__typename": "Query", "human": human.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["id": id]
     }
 
-    public var human: Human? {
-      get {
-        return (snapshot["human"] as? Snapshot).flatMap { Human(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "human")
-      }
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("human", arguments: ["id": GraphQLVariable("id")], type: .object(Human.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(human: Human? = nil) {
+            self.init(snapshot: ["__typename": "Query", "human": human.flatMap { $0.snapshot }])
+        }
+
+        public var human: Human? {
+            get {
+                return (snapshot["human"] as? Snapshot).flatMap { Human(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "human")
+            }
+        }
+
+        public struct Human: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                GraphQLField("mass", type: .scalar(Double.self)),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public init(name: String, mass: Double? = nil) {
+                self.init(snapshot: ["__typename": "Human", "name": name, "mass": mass])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// What this human calls themselves
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            /// Mass in kilograms, or null if unknown
+            public var mass: Double? {
+                get {
+                    return snapshot["mass"] as? Double
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "mass")
+                }
+            }
+        }
     }
-
-    public struct Human: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        GraphQLField("mass", type: .scalar(Double.self)),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public init(name: String, mass: Double? = nil) {
-        self.init(snapshot: ["__typename": "Human", "name": name, "mass": mass])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// What this human calls themselves
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      /// Mass in kilograms, or null if unknown
-      public var mass: Double? {
-        get {
-          return snapshot["mass"] as? Double
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "mass")
-        }
-      }
-    }
-  }
 }
 
 public final class SameHeroTwiceQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query SameHeroTwice {\n  hero {\n    __typename\n    name\n  }\n  r2: hero {\n    __typename\n    appearsIn\n  }\n}"
 
-  public init() {
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", type: .object(Hero.selections)),
-      GraphQLField("hero", alias: "r2", type: .object(R2.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init() {
     }
 
-    public init(hero: Hero? = nil, r2: R2? = nil) {
-      self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }, "r2": r2.flatMap { $0.snapshot }])
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("hero", type: .object(Hero.selections)),
+            GraphQLField("hero", alias: "r2", type: .object(R2.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(hero: Hero? = nil, r2: R2? = nil) {
+            self.init(snapshot: ["__typename": "Query", "hero": hero.flatMap { $0.snapshot }, "r2": r2.flatMap { $0.snapshot }])
+        }
+
+        public var hero: Hero? {
+            get {
+                return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "hero")
+            }
+        }
+
+        public var r2: R2? {
+            get {
+                return (snapshot["r2"] as? Snapshot).flatMap { R2(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "r2")
+            }
+        }
+
+        public struct Hero: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String) -> Hero {
+                return Hero(snapshot: ["__typename": "Human", "name": name])
+            }
+
+            public static func makeDroid(name: String) -> Hero {
+                return Hero(snapshot: ["__typename": "Droid", "name": name])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+        }
+
+        public struct R2: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(appearsIn: [Episode?]) -> R2 {
+                return R2(snapshot: ["__typename": "Human", "appearsIn": appearsIn])
+            }
+
+            public static func makeDroid(appearsIn: [Episode?]) -> R2 {
+                return R2(snapshot: ["__typename": "Droid", "appearsIn": appearsIn])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The movies this character appears in
+            public var appearsIn: [Episode?] {
+                get {
+                    return snapshot["appearsIn"]! as! [Episode?]
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "appearsIn")
+                }
+            }
+        }
     }
-
-    public var hero: Hero? {
-      get {
-        return (snapshot["hero"] as? Snapshot).flatMap { Hero(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "hero")
-      }
-    }
-
-    public var r2: R2? {
-      get {
-        return (snapshot["r2"] as? Snapshot).flatMap { R2(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "r2")
-      }
-    }
-
-    public struct Hero: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String) -> Hero {
-        return Hero(snapshot: ["__typename": "Human", "name": name])
-      }
-
-      public static func makeDroid(name: String) -> Hero {
-        return Hero(snapshot: ["__typename": "Droid", "name": name])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-    }
-
-    public struct R2: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(appearsIn: [Episode?]) -> R2 {
-        return R2(snapshot: ["__typename": "Human", "appearsIn": appearsIn])
-      }
-
-      public static func makeDroid(appearsIn: [Episode?]) -> R2 {
-        return R2(snapshot: ["__typename": "Droid", "appearsIn": appearsIn])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The movies this character appears in
-      public var appearsIn: [Episode?] {
-        get {
-          return snapshot["appearsIn"]! as! [Episode?]
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "appearsIn")
-        }
-      }
-    }
-  }
 }
 
 public final class StarshipQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query Starship {\n  starship(id: 3000) {\n    __typename\n    name\n    coordinates\n  }\n}"
 
-  public init() {
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("starship", arguments: ["id": 3000], type: .object(Starship.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init() {
     }
 
-    public init(starship: Starship? = nil) {
-      self.init(snapshot: ["__typename": "Query", "starship": starship.flatMap { $0.snapshot }])
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("starship", arguments: ["id": 3000], type: .object(Starship.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(starship: Starship? = nil) {
+            self.init(snapshot: ["__typename": "Query", "starship": starship.flatMap { $0.snapshot }])
+        }
+
+        public var starship: Starship? {
+            get {
+                return (snapshot["starship"] as? Snapshot).flatMap { Starship(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "starship")
+            }
+        }
+
+        public struct Starship: GraphQLSelectionSet {
+            public static let possibleTypes = ["Starship"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                GraphQLField("coordinates", type: .list(.nonNull(.list(.nonNull(.scalar(Double.self)))))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public init(name: String, coordinates: [[Double]]? = nil) {
+                self.init(snapshot: ["__typename": "Starship", "name": name, "coordinates": coordinates])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the starship
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            public var coordinates: [[Double]]? {
+                get {
+                    return snapshot["coordinates"] as? [[Double]]
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "coordinates")
+                }
+            }
+        }
     }
-
-    public var starship: Starship? {
-      get {
-        return (snapshot["starship"] as? Snapshot).flatMap { Starship(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "starship")
-      }
-    }
-
-    public struct Starship: GraphQLSelectionSet {
-      public static let possibleTypes = ["Starship"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-        GraphQLField("coordinates", type: .list(.nonNull(.list(.nonNull(.scalar(Double.self)))))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public init(name: String, coordinates: [[Double]]? = nil) {
-        self.init(snapshot: ["__typename": "Starship", "name": name, "coordinates": coordinates])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the starship
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-
-      public var coordinates: [[Double]]? {
-        get {
-          return snapshot["coordinates"] as? [[Double]]
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "coordinates")
-        }
-      }
-    }
-  }
 }
 
 public final class ReviewAddedSubscription: GraphQLSubscription {
-  public static let operationString =
+    public static let operationString =
     "subscription ReviewAdded($episode: Episode) {\n  reviewAdded(episode: $episode) {\n    __typename\n    episode\n    stars\n    commentary\n  }\n}"
 
-  public var episode: Episode?
+    public var episode: Episode?
 
-  public init(episode: Episode? = nil) {
-    self.episode = episode
-  }
-
-  public var variables: GraphQLMap? {
-    return ["episode": episode]
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Subscription"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("reviewAdded", arguments: ["episode": GraphQLVariable("episode")], type: .object(ReviewAdded.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init(episode: Episode? = nil) {
+        self.episode = episode
     }
 
-    public init(reviewAdded: ReviewAdded? = nil) {
-      self.init(snapshot: ["__typename": "Subscription", "reviewAdded": reviewAdded.flatMap { $0.snapshot }])
+    public var variables: GraphQLMap? {
+        return ["episode": episode]
     }
 
-    public var reviewAdded: ReviewAdded? {
-      get {
-        return (snapshot["reviewAdded"] as? Snapshot).flatMap { ReviewAdded(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "reviewAdded")
-      }
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Subscription"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("reviewAdded", arguments: ["episode": GraphQLVariable("episode")], type: .object(ReviewAdded.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(reviewAdded: ReviewAdded? = nil) {
+            self.init(snapshot: ["__typename": "Subscription", "reviewAdded": reviewAdded.flatMap { $0.snapshot }])
+        }
+
+        public var reviewAdded: ReviewAdded? {
+            get {
+                return (snapshot["reviewAdded"] as? Snapshot).flatMap { ReviewAdded(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "reviewAdded")
+            }
+        }
+
+        public struct ReviewAdded: GraphQLSelectionSet {
+            public static let possibleTypes = ["Review"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("episode", type: .scalar(Episode.self)),
+                GraphQLField("stars", type: .nonNull(.scalar(Int.self))),
+                GraphQLField("commentary", type: .scalar(String.self)),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public init(episode: Episode? = nil, stars: Int, commentary: String? = nil) {
+                self.init(snapshot: ["__typename": "Review", "episode": episode, "stars": stars, "commentary": commentary])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The movie
+            public var episode: Episode? {
+                get {
+                    return snapshot["episode"] as? Episode
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "episode")
+                }
+            }
+
+            /// The number of stars this review gave, 1-5
+            public var stars: Int {
+                get {
+                    return snapshot["stars"]! as! Int
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "stars")
+                }
+            }
+
+            /// Comment about the movie
+            public var commentary: String? {
+                get {
+                    return snapshot["commentary"] as? String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "commentary")
+                }
+            }
+        }
     }
-
-    public struct ReviewAdded: GraphQLSelectionSet {
-      public static let possibleTypes = ["Review"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("episode", type: .scalar(Episode.self)),
-        GraphQLField("stars", type: .nonNull(.scalar(Int.self))),
-        GraphQLField("commentary", type: .scalar(String.self)),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public init(episode: Episode? = nil, stars: Int, commentary: String? = nil) {
-        self.init(snapshot: ["__typename": "Review", "episode": episode, "stars": stars, "commentary": commentary])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The movie
-      public var episode: Episode? {
-        get {
-          return snapshot["episode"] as? Episode
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "episode")
-        }
-      }
-
-      /// The number of stars this review gave, 1-5
-      public var stars: Int {
-        get {
-          return snapshot["stars"]! as! Int
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "stars")
-        }
-      }
-
-      /// Comment about the movie
-      public var commentary: String? {
-        get {
-          return snapshot["commentary"] as? String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "commentary")
-        }
-      }
-    }
-  }
 }
 
 public final class TwoHeroesQuery: GraphQLQuery {
-  public static let operationString =
+    public static let operationString =
     "query TwoHeroes {\n  r2: hero {\n    __typename\n    name\n  }\n  luke: hero(episode: EMPIRE) {\n    __typename\n    name\n  }\n}"
 
-  public init() {
-  }
-
-  public struct Data: GraphQLSelectionSet {
-    public static let possibleTypes = ["Query"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("hero", alias: "r2", type: .object(R2.selections)),
-      GraphQLField("hero", alias: "luke", arguments: ["episode": "EMPIRE"], type: .object(Luke.selections)),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+    public init() {
     }
 
-    public init(r2: R2? = nil, luke: Luke? = nil) {
-      self.init(snapshot: ["__typename": "Query", "r2": r2.flatMap { $0.snapshot }, "luke": luke.flatMap { $0.snapshot }])
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("hero", alias: "r2", type: .object(R2.selections)),
+            GraphQLField("hero", alias: "luke", arguments: ["episode": "EMPIRE"], type: .object(Luke.selections)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(r2: R2? = nil, luke: Luke? = nil) {
+            self.init(snapshot: ["__typename": "Query", "r2": r2.flatMap { $0.snapshot }, "luke": luke.flatMap { $0.snapshot }])
+        }
+
+        public var r2: R2? {
+            get {
+                return (snapshot["r2"] as? Snapshot).flatMap { R2(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "r2")
+            }
+        }
+
+        public var luke: Luke? {
+            get {
+                return (snapshot["luke"] as? Snapshot).flatMap { Luke(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "luke")
+            }
+        }
+
+        public struct R2: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String) -> R2 {
+                return R2(snapshot: ["__typename": "Human", "name": name])
+            }
+
+            public static func makeDroid(name: String) -> R2 {
+                return R2(snapshot: ["__typename": "Droid", "name": name])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+        }
+
+        public struct Luke: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String) -> Luke {
+                return Luke(snapshot: ["__typename": "Human", "name": name])
+            }
+
+            public static func makeDroid(name: String) -> Luke {
+                return Luke(snapshot: ["__typename": "Droid", "name": name])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+        }
     }
-
-    public var r2: R2? {
-      get {
-        return (snapshot["r2"] as? Snapshot).flatMap { R2(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "r2")
-      }
-    }
-
-    public var luke: Luke? {
-      get {
-        return (snapshot["luke"] as? Snapshot).flatMap { Luke(snapshot: $0) }
-      }
-      set {
-        snapshot.updateValue(newValue?.snapshot, forKey: "luke")
-      }
-    }
-
-    public struct R2: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String) -> R2 {
-        return R2(snapshot: ["__typename": "Human", "name": name])
-      }
-
-      public static func makeDroid(name: String) -> R2 {
-        return R2(snapshot: ["__typename": "Droid", "name": name])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-    }
-
-    public struct Luke: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String) -> Luke {
-        return Luke(snapshot: ["__typename": "Human", "name": name])
-      }
-
-      public static func makeDroid(name: String) -> Luke {
-        return Luke(snapshot: ["__typename": "Droid", "name": name])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-    }
-  }
 }
 
 public struct DroidNameAndPrimaryFunction: GraphQLFragment {
-  public static let fragmentString =
+    public static let fragmentString =
     "fragment DroidNameAndPrimaryFunction on Droid {\n  __typename\n  ...CharacterName\n  ...DroidPrimaryFunction\n}"
 
-  public static let possibleTypes = ["Droid"]
-
-  public static let selections: [GraphQLSelection] = [
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("name", type: .nonNull(.scalar(String.self))),
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("primaryFunction", type: .scalar(String.self)),
-  ]
-
-  public var snapshot: Snapshot
-
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public init(name: String, primaryFunction: String? = nil) {
-    self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
-
-  /// What others call this droid
-  public var name: String {
-    get {
-      return snapshot["name"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "name")
-    }
-  }
-
-  /// This droid's primary function
-  public var primaryFunction: String? {
-    get {
-      return snapshot["primaryFunction"] as? String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "primaryFunction")
-    }
-  }
-
-  public var fragments: Fragments {
-    get {
-      return Fragments(snapshot: snapshot)
-    }
-    set {
-      snapshot += newValue.snapshot
-    }
-  }
-
-  public struct Fragments {
-    public var snapshot: Snapshot
-
-    public var characterName: CharacterName {
-      get {
-        return CharacterName(snapshot: snapshot)
-      }
-      set {
-        snapshot += newValue.snapshot
-      }
-    }
-
-    public var droidPrimaryFunction: DroidPrimaryFunction {
-      get {
-        return DroidPrimaryFunction(snapshot: snapshot)
-      }
-      set {
-        snapshot += newValue.snapshot
-      }
-    }
-  }
-}
-
-public struct CharacterNameAndDroidPrimaryFunction: GraphQLFragment {
-  public static let fragmentString =
-    "fragment CharacterNameAndDroidPrimaryFunction on Character {\n  __typename\n  ...CharacterName\n  ...DroidPrimaryFunction\n}"
-
-  public static let possibleTypes = ["Human", "Droid"]
-
-  public static let selections: [GraphQLSelection] = [
-    GraphQLTypeCase(
-      variants: ["Droid": AsDroid.selections],
-      default: [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      ]
-    )
-  ]
-
-  public var snapshot: Snapshot
-
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public static func makeHuman(name: String) -> CharacterNameAndDroidPrimaryFunction {
-    return CharacterNameAndDroidPrimaryFunction(snapshot: ["__typename": "Human", "name": name])
-  }
-
-  public static func makeDroid(name: String, primaryFunction: String? = nil) -> CharacterNameAndDroidPrimaryFunction {
-    return CharacterNameAndDroidPrimaryFunction(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
-
-  /// The name of the character
-  public var name: String {
-    get {
-      return snapshot["name"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "name")
-    }
-  }
-
-  public var fragments: Fragments {
-    get {
-      return Fragments(snapshot: snapshot)
-    }
-    set {
-      snapshot += newValue.snapshot
-    }
-  }
-
-  public struct Fragments {
-    public var snapshot: Snapshot
-
-    public var characterName: CharacterName {
-      get {
-        return CharacterName(snapshot: snapshot)
-      }
-      set {
-        snapshot += newValue.snapshot
-      }
-    }
-
-    public var droidPrimaryFunction: DroidPrimaryFunction? {
-      get {
-        if !DroidPrimaryFunction.possibleTypes.contains(snapshot["__typename"]! as! String) { return nil }
-        return DroidPrimaryFunction(snapshot: snapshot)
-      }
-      set {
-        guard let newValue = newValue else { return }
-        snapshot += newValue.snapshot
-      }
-    }
-  }
-
-  public var asDroid: AsDroid? {
-    get {
-      if !AsDroid.possibleTypes.contains(__typename) { return nil }
-      return AsDroid(snapshot: snapshot)
-    }
-    set {
-      guard let newValue = newValue else { return }
-      snapshot = newValue.snapshot
-    }
-  }
-
-  public struct AsDroid: GraphQLSelectionSet {
     public static let possibleTypes = ["Droid"]
 
     public static let selections: [GraphQLSelection] = [
-      GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-      GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-      GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-      GraphQLField("primaryFunction", type: .scalar(String.self)),
-    ]
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("primaryFunction", type: .scalar(String.self)),
+        ]
 
     public var snapshot: Snapshot
 
     public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+        self.snapshot = snapshot
     }
 
     public init(name: String, primaryFunction: String? = nil) {
-      self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+        self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
     }
 
     public var __typename: String {
-      get {
-        return snapshot["__typename"]! as! String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "__typename")
-      }
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
     }
 
     /// What others call this droid
     public var name: String {
-      get {
-        return snapshot["name"]! as! String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "name")
-      }
+        get {
+            return snapshot["name"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "name")
+        }
     }
 
     /// This droid's primary function
     public var primaryFunction: String? {
-      get {
-        return snapshot["primaryFunction"] as? String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "primaryFunction")
-      }
+        get {
+            return snapshot["primaryFunction"] as? String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "primaryFunction")
+        }
     }
 
     public var fragments: Fragments {
-      get {
-        return Fragments(snapshot: snapshot)
-      }
-      set {
-        snapshot += newValue.snapshot
-      }
+        get {
+            return Fragments(snapshot: snapshot)
+        }
+        set {
+            snapshot += newValue.snapshot
+        }
     }
 
     public struct Fragments {
-      public var snapshot: Snapshot
+        public var snapshot: Snapshot
 
-      public var characterName: CharacterName {
-        get {
-          return CharacterName(snapshot: snapshot)
+        public var characterName: CharacterName {
+            get {
+                return CharacterName(snapshot: snapshot)
+            }
+            set {
+                snapshot += newValue.snapshot
+            }
         }
-        set {
-          snapshot += newValue.snapshot
-        }
-      }
 
-      public var droidPrimaryFunction: DroidPrimaryFunction {
-        get {
-          return DroidPrimaryFunction(snapshot: snapshot)
+        public var droidPrimaryFunction: DroidPrimaryFunction {
+            get {
+                return DroidPrimaryFunction(snapshot: snapshot)
+            }
+            set {
+                snapshot += newValue.snapshot
+            }
         }
-        set {
-          snapshot += newValue.snapshot
-        }
-      }
     }
-  }
 }
 
-public struct CharacterNameAndDroidAppearsIn: GraphQLFragment {
-  public static let fragmentString =
-    "fragment CharacterNameAndDroidAppearsIn on Character {\n  __typename\n  name\n  ... on Droid {\n    appearsIn\n  }\n}"
+public struct CharacterNameAndDroidPrimaryFunction: GraphQLFragment {
+    public static let fragmentString =
+    "fragment CharacterNameAndDroidPrimaryFunction on Character {\n  __typename\n  ...CharacterName\n  ...DroidPrimaryFunction\n}"
 
-  public static let possibleTypes = ["Human", "Droid"]
-
-  public static let selections: [GraphQLSelection] = [
-    GraphQLTypeCase(
-      variants: ["Droid": AsDroid.selections],
-      default: [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      ]
-    )
-  ]
-
-  public var snapshot: Snapshot
-
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public static func makeHuman(name: String) -> CharacterNameAndDroidAppearsIn {
-    return CharacterNameAndDroidAppearsIn(snapshot: ["__typename": "Human", "name": name])
-  }
-
-  public static func makeDroid(name: String, appearsIn: [Episode?]) -> CharacterNameAndDroidAppearsIn {
-    return CharacterNameAndDroidAppearsIn(snapshot: ["__typename": "Droid", "name": name, "appearsIn": appearsIn])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
-
-  /// The name of the character
-  public var name: String {
-    get {
-      return snapshot["name"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "name")
-    }
-  }
-
-  public var asDroid: AsDroid? {
-    get {
-      if !AsDroid.possibleTypes.contains(__typename) { return nil }
-      return AsDroid(snapshot: snapshot)
-    }
-    set {
-      guard let newValue = newValue else { return }
-      snapshot = newValue.snapshot
-    }
-  }
-
-  public struct AsDroid: GraphQLSelectionSet {
-    public static let possibleTypes = ["Droid"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-      GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
-    }
-
-    public init(name: String, appearsIn: [Episode?]) {
-      self.init(snapshot: ["__typename": "Droid", "name": name, "appearsIn": appearsIn])
-    }
-
-    public var __typename: String {
-      get {
-        return snapshot["__typename"]! as! String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "__typename")
-      }
-    }
-
-    /// What others call this droid
-    public var name: String {
-      get {
-        return snapshot["name"]! as! String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "name")
-      }
-    }
-
-    /// The movies this droid appears in
-    public var appearsIn: [Episode?] {
-      get {
-        return snapshot["appearsIn"]! as! [Episode?]
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "appearsIn")
-      }
-    }
-  }
-}
-
-public struct DroidName: GraphQLFragment {
-  public static let fragmentString =
-    "fragment DroidName on Droid {\n  __typename\n  name\n}"
-
-  public static let possibleTypes = ["Droid"]
-
-  public static let selections: [GraphQLSelection] = [
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("name", type: .nonNull(.scalar(String.self))),
-  ]
-
-  public var snapshot: Snapshot
-
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public init(name: String) {
-    self.init(snapshot: ["__typename": "Droid", "name": name])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
-
-  /// What others call this droid
-  public var name: String {
-    get {
-      return snapshot["name"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "name")
-    }
-  }
-}
-
-public struct DroidPrimaryFunction: GraphQLFragment {
-  public static let fragmentString =
-    "fragment DroidPrimaryFunction on Droid {\n  __typename\n  primaryFunction\n}"
-
-  public static let possibleTypes = ["Droid"]
-
-  public static let selections: [GraphQLSelection] = [
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("primaryFunction", type: .scalar(String.self)),
-  ]
-
-  public var snapshot: Snapshot
-
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public init(primaryFunction: String? = nil) {
-    self.init(snapshot: ["__typename": "Droid", "primaryFunction": primaryFunction])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
-
-  /// This droid's primary function
-  public var primaryFunction: String? {
-    get {
-      return snapshot["primaryFunction"] as? String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "primaryFunction")
-    }
-  }
-}
-
-public struct HumanHeightWithVariable: GraphQLFragment {
-  public static let fragmentString =
-    "fragment HumanHeightWithVariable on Human {\n  __typename\n  height(unit: $heightUnit)\n}"
-
-  public static let possibleTypes = ["Human"]
-
-  public static let selections: [GraphQLSelection] = [
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("height", arguments: ["unit": GraphQLVariable("heightUnit")], type: .scalar(Double.self)),
-  ]
-
-  public var snapshot: Snapshot
-
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public init(height: Double? = nil) {
-    self.init(snapshot: ["__typename": "Human", "height": height])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
-
-  /// Height in the preferred unit, default is meters
-  public var height: Double? {
-    get {
-      return snapshot["height"] as? Double
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "height")
-    }
-  }
-}
-
-public struct CharacterNameAndAppearsInWithNestedFragments: GraphQLFragment {
-  public static let fragmentString =
-    "fragment CharacterNameAndAppearsInWithNestedFragments on Character {\n  __typename\n  ...CharacterNameWithNestedAppearsInFragment\n}"
-
-  public static let possibleTypes = ["Human", "Droid"]
-
-  public static let selections: [GraphQLSelection] = [
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("name", type: .nonNull(.scalar(String.self))),
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
-  ]
-
-  public var snapshot: Snapshot
-
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public static func makeHuman(name: String, appearsIn: [Episode?]) -> CharacterNameAndAppearsInWithNestedFragments {
-    return CharacterNameAndAppearsInWithNestedFragments(snapshot: ["__typename": "Human", "name": name, "appearsIn": appearsIn])
-  }
-
-  public static func makeDroid(name: String, appearsIn: [Episode?]) -> CharacterNameAndAppearsInWithNestedFragments {
-    return CharacterNameAndAppearsInWithNestedFragments(snapshot: ["__typename": "Droid", "name": name, "appearsIn": appearsIn])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
-
-  /// The name of the character
-  public var name: String {
-    get {
-      return snapshot["name"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "name")
-    }
-  }
-
-  /// The movies this character appears in
-  public var appearsIn: [Episode?] {
-    get {
-      return snapshot["appearsIn"]! as! [Episode?]
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "appearsIn")
-    }
-  }
-
-  public var fragments: Fragments {
-    get {
-      return Fragments(snapshot: snapshot)
-    }
-    set {
-      snapshot += newValue.snapshot
-    }
-  }
-
-  public struct Fragments {
-    public var snapshot: Snapshot
-
-    public var characterNameWithNestedAppearsInFragment: CharacterNameWithNestedAppearsInFragment {
-      get {
-        return CharacterNameWithNestedAppearsInFragment(snapshot: snapshot)
-      }
-      set {
-        snapshot += newValue.snapshot
-      }
-    }
-
-    public var characterAppearsIn: CharacterAppearsIn {
-      get {
-        return CharacterAppearsIn(snapshot: snapshot)
-      }
-      set {
-        snapshot += newValue.snapshot
-      }
-    }
-  }
-}
-
-public struct CharacterNameWithNestedAppearsInFragment: GraphQLFragment {
-  public static let fragmentString =
-    "fragment CharacterNameWithNestedAppearsInFragment on Character {\n  __typename\n  name\n  ...CharacterAppearsIn\n}"
-
-  public static let possibleTypes = ["Human", "Droid"]
-
-  public static let selections: [GraphQLSelection] = [
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("name", type: .nonNull(.scalar(String.self))),
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
-  ]
-
-  public var snapshot: Snapshot
-
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public static func makeHuman(name: String, appearsIn: [Episode?]) -> CharacterNameWithNestedAppearsInFragment {
-    return CharacterNameWithNestedAppearsInFragment(snapshot: ["__typename": "Human", "name": name, "appearsIn": appearsIn])
-  }
-
-  public static func makeDroid(name: String, appearsIn: [Episode?]) -> CharacterNameWithNestedAppearsInFragment {
-    return CharacterNameWithNestedAppearsInFragment(snapshot: ["__typename": "Droid", "name": name, "appearsIn": appearsIn])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
-
-  /// The name of the character
-  public var name: String {
-    get {
-      return snapshot["name"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "name")
-    }
-  }
-
-  /// The movies this character appears in
-  public var appearsIn: [Episode?] {
-    get {
-      return snapshot["appearsIn"]! as! [Episode?]
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "appearsIn")
-    }
-  }
-
-  public var fragments: Fragments {
-    get {
-      return Fragments(snapshot: snapshot)
-    }
-    set {
-      snapshot += newValue.snapshot
-    }
-  }
-
-  public struct Fragments {
-    public var snapshot: Snapshot
-
-    public var characterAppearsIn: CharacterAppearsIn {
-      get {
-        return CharacterAppearsIn(snapshot: snapshot)
-      }
-      set {
-        snapshot += newValue.snapshot
-      }
-    }
-  }
-}
-
-public struct CharacterNameWithInlineFragment: GraphQLFragment {
-  public static let fragmentString =
-    "fragment CharacterNameWithInlineFragment on Character {\n  __typename\n  ... on Human {\n    friends {\n      __typename\n      appearsIn\n    }\n  }\n  ... on Droid {\n    ...CharacterName\n    ...FriendsNames\n  }\n}"
-
-  public static let possibleTypes = ["Human", "Droid"]
-
-  public static let selections: [GraphQLSelection] = [
-    GraphQLTypeCase(
-      variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections],
-      default: [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-      ]
-    )
-  ]
-
-  public var snapshot: Snapshot
-
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public static func makeHuman(friends: [AsHuman.Friend?]? = nil) -> CharacterNameWithInlineFragment {
-    return CharacterNameWithInlineFragment(snapshot: ["__typename": "Human", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-  }
-
-  public static func makeDroid(name: String, friends: [AsDroid.Friend?]? = nil) -> CharacterNameWithInlineFragment {
-    return CharacterNameWithInlineFragment(snapshot: ["__typename": "Droid", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
-
-  public var asHuman: AsHuman? {
-    get {
-      if !AsHuman.possibleTypes.contains(__typename) { return nil }
-      return AsHuman(snapshot: snapshot)
-    }
-    set {
-      guard let newValue = newValue else { return }
-      snapshot = newValue.snapshot
-    }
-  }
-
-  public struct AsHuman: GraphQLSelectionSet {
-    public static let possibleTypes = ["Human"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-      GraphQLField("friends", type: .list(.object(Friend.selections))),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
-    }
-
-    public init(friends: [Friend?]? = nil) {
-      self.init(snapshot: ["__typename": "Human", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-    }
-
-    public var __typename: String {
-      get {
-        return snapshot["__typename"]! as! String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "__typename")
-      }
-    }
-
-    /// This human's friends, or an empty list if they have none
-    public var friends: [Friend?]? {
-      get {
-        return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-      }
-      set {
-        snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-      }
-    }
-
-    public struct Friend: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(appearsIn: [Episode?]) -> Friend {
-        return Friend(snapshot: ["__typename": "Human", "appearsIn": appearsIn])
-      }
-
-      public static func makeDroid(appearsIn: [Episode?]) -> Friend {
-        return Friend(snapshot: ["__typename": "Droid", "appearsIn": appearsIn])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The movies this character appears in
-      public var appearsIn: [Episode?] {
-        get {
-          return snapshot["appearsIn"]! as! [Episode?]
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "appearsIn")
-        }
-      }
-    }
-  }
-
-  public var asDroid: AsDroid? {
-    get {
-      if !AsDroid.possibleTypes.contains(__typename) { return nil }
-      return AsDroid(snapshot: snapshot)
-    }
-    set {
-      guard let newValue = newValue else { return }
-      snapshot = newValue.snapshot
-    }
-  }
-
-  public struct AsDroid: GraphQLSelectionSet {
-    public static let possibleTypes = ["Droid"]
-
-    public static let selections: [GraphQLSelection] = [
-      GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-      GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-      GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-      GraphQLField("friends", type: .list(.object(Friend.selections))),
-    ]
-
-    public var snapshot: Snapshot
-
-    public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
-    }
-
-    public init(name: String, friends: [Friend?]? = nil) {
-      self.init(snapshot: ["__typename": "Droid", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-    }
-
-    public var __typename: String {
-      get {
-        return snapshot["__typename"]! as! String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "__typename")
-      }
-    }
-
-    /// What others call this droid
-    public var name: String {
-      get {
-        return snapshot["name"]! as! String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "name")
-      }
-    }
-
-    /// This droid's friends, or an empty list if they have none
-    public var friends: [Friend?]? {
-      get {
-        return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-      }
-      set {
-        snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-      }
-    }
-
-    public var fragments: Fragments {
-      get {
-        return Fragments(snapshot: snapshot)
-      }
-      set {
-        snapshot += newValue.snapshot
-      }
-    }
-
-    public struct Fragments {
-      public var snapshot: Snapshot
-
-      public var characterName: CharacterName {
-        get {
-          return CharacterName(snapshot: snapshot)
-        }
-        set {
-          snapshot += newValue.snapshot
-        }
-      }
-
-      public var friendsNames: FriendsNames {
-        get {
-          return FriendsNames(snapshot: snapshot)
-        }
-        set {
-          snapshot += newValue.snapshot
-        }
-      }
-    }
-
-    public struct Friend: GraphQLSelectionSet {
-      public static let possibleTypes = ["Human", "Droid"]
-
-      public static let selections: [GraphQLSelection] = [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      ]
-
-      public var snapshot: Snapshot
-
-      public init(snapshot: Snapshot) {
-        self.snapshot = snapshot
-      }
-
-      public static func makeHuman(name: String) -> Friend {
-        return Friend(snapshot: ["__typename": "Human", "name": name])
-      }
-
-      public static func makeDroid(name: String) -> Friend {
-        return Friend(snapshot: ["__typename": "Droid", "name": name])
-      }
-
-      public var __typename: String {
-        get {
-          return snapshot["__typename"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "__typename")
-        }
-      }
-
-      /// The name of the character
-      public var name: String {
-        get {
-          return snapshot["name"]! as! String
-        }
-        set {
-          snapshot.updateValue(newValue, forKey: "name")
-        }
-      }
-    }
-  }
-}
-
-public struct FriendsNames: GraphQLFragment {
-  public static let fragmentString =
-    "fragment FriendsNames on Character {\n  __typename\n  friends {\n    __typename\n    name\n  }\n}"
-
-  public static let possibleTypes = ["Human", "Droid"]
-
-  public static let selections: [GraphQLSelection] = [
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("friends", type: .list(.object(Friend.selections))),
-  ]
-
-  public var snapshot: Snapshot
-
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public static func makeHuman(friends: [Friend?]? = nil) -> FriendsNames {
-    return FriendsNames(snapshot: ["__typename": "Human", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-  }
-
-  public static func makeDroid(friends: [Friend?]? = nil) -> FriendsNames {
-    return FriendsNames(snapshot: ["__typename": "Droid", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
-
-  /// The friends of the character, or an empty list if they have none
-  public var friends: [Friend?]? {
-    get {
-      return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
-    }
-    set {
-      snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
-    }
-  }
-
-  public struct Friend: GraphQLSelectionSet {
     public static let possibleTypes = ["Human", "Droid"]
 
     public static let selections: [GraphQLSelection] = [
-      GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-      GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        GraphQLTypeCase(
+            variants: ["Droid": AsDroid.selections],
+            default: [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                ]
+        )
     ]
 
     public var snapshot: Snapshot
 
     public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+        self.snapshot = snapshot
     }
 
-    public static func makeHuman(name: String) -> Friend {
-      return Friend(snapshot: ["__typename": "Human", "name": name])
+    public static func makeHuman(name: String) -> CharacterNameAndDroidPrimaryFunction {
+        return CharacterNameAndDroidPrimaryFunction(snapshot: ["__typename": "Human", "name": name])
     }
 
-    public static func makeDroid(name: String) -> Friend {
-      return Friend(snapshot: ["__typename": "Droid", "name": name])
+    public static func makeDroid(name: String, primaryFunction: String? = nil) -> CharacterNameAndDroidPrimaryFunction {
+        return CharacterNameAndDroidPrimaryFunction(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
     }
 
     public var __typename: String {
-      get {
-        return snapshot["__typename"]! as! String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "__typename")
-      }
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
     }
 
     /// The name of the character
     public var name: String {
-      get {
-        return snapshot["name"]! as! String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "name")
-      }
+        get {
+            return snapshot["name"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "name")
+        }
     }
-  }
+
+    public var fragments: Fragments {
+        get {
+            return Fragments(snapshot: snapshot)
+        }
+        set {
+            snapshot += newValue.snapshot
+        }
+    }
+
+    public struct Fragments {
+        public var snapshot: Snapshot
+
+        public var characterName: CharacterName {
+            get {
+                return CharacterName(snapshot: snapshot)
+            }
+            set {
+                snapshot += newValue.snapshot
+            }
+        }
+
+        public var droidPrimaryFunction: DroidPrimaryFunction? {
+            get {
+                if !DroidPrimaryFunction.possibleTypes.contains(snapshot["__typename"]! as! String) { return nil }
+                return DroidPrimaryFunction(snapshot: snapshot)
+            }
+            set {
+                guard let newValue = newValue else { return }
+                snapshot += newValue.snapshot
+            }
+        }
+    }
+
+    public var asDroid: AsDroid? {
+        get {
+            if !AsDroid.possibleTypes.contains(__typename) { return nil }
+            return AsDroid(snapshot: snapshot)
+        }
+        set {
+            guard let newValue = newValue else { return }
+            snapshot = newValue.snapshot
+        }
+    }
+
+    public struct AsDroid: GraphQLSelectionSet {
+        public static let possibleTypes = ["Droid"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("primaryFunction", type: .scalar(String.self)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(name: String, primaryFunction: String? = nil) {
+            self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+        }
+
+        public var __typename: String {
+            get {
+                return snapshot["__typename"]! as! String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "__typename")
+            }
+        }
+
+        /// What others call this droid
+        public var name: String {
+            get {
+                return snapshot["name"]! as! String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "name")
+            }
+        }
+
+        /// This droid's primary function
+        public var primaryFunction: String? {
+            get {
+                return snapshot["primaryFunction"] as? String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "primaryFunction")
+            }
+        }
+
+        public var fragments: Fragments {
+            get {
+                return Fragments(snapshot: snapshot)
+            }
+            set {
+                snapshot += newValue.snapshot
+            }
+        }
+
+        public struct Fragments {
+            public var snapshot: Snapshot
+
+            public var characterName: CharacterName {
+                get {
+                    return CharacterName(snapshot: snapshot)
+                }
+                set {
+                    snapshot += newValue.snapshot
+                }
+            }
+
+            public var droidPrimaryFunction: DroidPrimaryFunction {
+                get {
+                    return DroidPrimaryFunction(snapshot: snapshot)
+                }
+                set {
+                    snapshot += newValue.snapshot
+                }
+            }
+        }
+    }
 }
 
-public struct CharacterAppearsIn: GraphQLFragment {
-  public static let fragmentString =
-    "fragment CharacterAppearsIn on Character {\n  __typename\n  appearsIn\n}"
+public struct CharacterNameAndDroidAppearsIn: GraphQLFragment {
+    public static let fragmentString =
+    "fragment CharacterNameAndDroidAppearsIn on Character {\n  __typename\n  name\n  ... on Droid {\n    appearsIn\n  }\n}"
 
-  public static let possibleTypes = ["Human", "Droid"]
-
-  public static let selections: [GraphQLSelection] = [
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
-  ]
-
-  public var snapshot: Snapshot
-
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public static func makeHuman(appearsIn: [Episode?]) -> CharacterAppearsIn {
-    return CharacterAppearsIn(snapshot: ["__typename": "Human", "appearsIn": appearsIn])
-  }
-
-  public static func makeDroid(appearsIn: [Episode?]) -> CharacterAppearsIn {
-    return CharacterAppearsIn(snapshot: ["__typename": "Droid", "appearsIn": appearsIn])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
-
-  /// The movies this character appears in
-  public var appearsIn: [Episode?] {
-    get {
-      return snapshot["appearsIn"]! as! [Episode?]
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "appearsIn")
-    }
-  }
-}
-
-public struct HeroDetails: GraphQLFragment {
-  public static let fragmentString =
-    "fragment HeroDetails on Character {\n  __typename\n  name\n  ... on Human {\n    height\n  }\n  ... on Droid {\n    primaryFunction\n  }\n}"
-
-  public static let possibleTypes = ["Human", "Droid"]
-
-  public static let selections: [GraphQLSelection] = [
-    GraphQLTypeCase(
-      variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections],
-      default: [
-        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      ]
-    )
-  ]
-
-  public var snapshot: Snapshot
-
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public static func makeHuman(name: String, height: Double? = nil) -> HeroDetails {
-    return HeroDetails(snapshot: ["__typename": "Human", "name": name, "height": height])
-  }
-
-  public static func makeDroid(name: String, primaryFunction: String? = nil) -> HeroDetails {
-    return HeroDetails(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
-
-  /// The name of the character
-  public var name: String {
-    get {
-      return snapshot["name"]! as! String
-    }
-    set {
-      snapshot.updateValue(newValue, forKey: "name")
-    }
-  }
-
-  public var asHuman: AsHuman? {
-    get {
-      if !AsHuman.possibleTypes.contains(__typename) { return nil }
-      return AsHuman(snapshot: snapshot)
-    }
-    set {
-      guard let newValue = newValue else { return }
-      snapshot = newValue.snapshot
-    }
-  }
-
-  public struct AsHuman: GraphQLSelectionSet {
-    public static let possibleTypes = ["Human"]
+    public static let possibleTypes = ["Human", "Droid"]
 
     public static let selections: [GraphQLSelection] = [
-      GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-      GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      GraphQLField("height", type: .scalar(Double.self)),
+        GraphQLTypeCase(
+            variants: ["Droid": AsDroid.selections],
+            default: [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                ]
+        )
     ]
 
     public var snapshot: Snapshot
 
     public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+        self.snapshot = snapshot
     }
 
-    public init(name: String, height: Double? = nil) {
-      self.init(snapshot: ["__typename": "Human", "name": name, "height": height])
+    public static func makeHuman(name: String) -> CharacterNameAndDroidAppearsIn {
+        return CharacterNameAndDroidAppearsIn(snapshot: ["__typename": "Human", "name": name])
+    }
+
+    public static func makeDroid(name: String, appearsIn: [Episode?]) -> CharacterNameAndDroidAppearsIn {
+        return CharacterNameAndDroidAppearsIn(snapshot: ["__typename": "Droid", "name": name, "appearsIn": appearsIn])
     }
 
     public var __typename: String {
-      get {
-        return snapshot["__typename"]! as! String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "__typename")
-      }
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
     }
 
-    /// What this human calls themselves
+    /// The name of the character
     public var name: String {
-      get {
-        return snapshot["name"]! as! String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "name")
-      }
+        get {
+            return snapshot["name"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "name")
+        }
     }
 
-    /// Height in the preferred unit, default is meters
-    public var height: Double? {
-      get {
-        return snapshot["height"] as? Double
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "height")
-      }
+    public var asDroid: AsDroid? {
+        get {
+            if !AsDroid.possibleTypes.contains(__typename) { return nil }
+            return AsDroid(snapshot: snapshot)
+        }
+        set {
+            guard let newValue = newValue else { return }
+            snapshot = newValue.snapshot
+        }
     }
-  }
 
-  public var asDroid: AsDroid? {
-    get {
-      if !AsDroid.possibleTypes.contains(__typename) { return nil }
-      return AsDroid(snapshot: snapshot)
-    }
-    set {
-      guard let newValue = newValue else { return }
-      snapshot = newValue.snapshot
-    }
-  }
+    public struct AsDroid: GraphQLSelectionSet {
+        public static let possibleTypes = ["Droid"]
 
-  public struct AsDroid: GraphQLSelectionSet {
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+            GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(name: String, appearsIn: [Episode?]) {
+            self.init(snapshot: ["__typename": "Droid", "name": name, "appearsIn": appearsIn])
+        }
+
+        public var __typename: String {
+            get {
+                return snapshot["__typename"]! as! String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "__typename")
+            }
+        }
+
+        /// What others call this droid
+        public var name: String {
+            get {
+                return snapshot["name"]! as! String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "name")
+            }
+        }
+
+        /// The movies this droid appears in
+        public var appearsIn: [Episode?] {
+            get {
+                return snapshot["appearsIn"]! as! [Episode?]
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "appearsIn")
+            }
+        }
+    }
+}
+
+public struct DroidName: GraphQLFragment {
+    public static let fragmentString =
+    "fragment DroidName on Droid {\n  __typename\n  name\n}"
+
     public static let possibleTypes = ["Droid"]
 
     public static let selections: [GraphQLSelection] = [
-      GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-      GraphQLField("name", type: .nonNull(.scalar(String.self))),
-      GraphQLField("primaryFunction", type: .scalar(String.self)),
-    ]
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        ]
 
     public var snapshot: Snapshot
 
     public init(snapshot: Snapshot) {
-      self.snapshot = snapshot
+        self.snapshot = snapshot
     }
 
-    public init(name: String, primaryFunction: String? = nil) {
-      self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+    public init(name: String) {
+        self.init(snapshot: ["__typename": "Droid", "name": name])
     }
 
     public var __typename: String {
-      get {
-        return snapshot["__typename"]! as! String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "__typename")
-      }
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
     }
 
     /// What others call this droid
     public var name: String {
-      get {
-        return snapshot["name"]! as! String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "name")
-      }
+        get {
+            return snapshot["name"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "name")
+        }
+    }
+}
+
+public struct DroidPrimaryFunction: GraphQLFragment {
+    public static let fragmentString =
+    "fragment DroidPrimaryFunction on Droid {\n  __typename\n  primaryFunction\n}"
+
+    public static let possibleTypes = ["Droid"]
+
+    public static let selections: [GraphQLSelection] = [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("primaryFunction", type: .scalar(String.self)),
+        ]
+
+    public var snapshot: Snapshot
+
+    public init(snapshot: Snapshot) {
+        self.snapshot = snapshot
+    }
+
+    public init(primaryFunction: String? = nil) {
+        self.init(snapshot: ["__typename": "Droid", "primaryFunction": primaryFunction])
+    }
+
+    public var __typename: String {
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
     }
 
     /// This droid's primary function
     public var primaryFunction: String? {
-      get {
-        return snapshot["primaryFunction"] as? String
-      }
-      set {
-        snapshot.updateValue(newValue, forKey: "primaryFunction")
-      }
+        get {
+            return snapshot["primaryFunction"] as? String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "primaryFunction")
+        }
     }
-  }
+}
+
+public struct HumanHeightWithVariable: GraphQLFragment {
+    public static let fragmentString =
+    "fragment HumanHeightWithVariable on Human {\n  __typename\n  height(unit: $heightUnit)\n}"
+
+    public static let possibleTypes = ["Human"]
+
+    public static let selections: [GraphQLSelection] = [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("height", arguments: ["unit": GraphQLVariable("heightUnit")], type: .scalar(Double.self)),
+        ]
+
+    public var snapshot: Snapshot
+
+    public init(snapshot: Snapshot) {
+        self.snapshot = snapshot
+    }
+
+    public init(height: Double? = nil) {
+        self.init(snapshot: ["__typename": "Human", "height": height])
+    }
+
+    public var __typename: String {
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
+    }
+
+    /// Height in the preferred unit, default is meters
+    public var height: Double? {
+        get {
+            return snapshot["height"] as? Double
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "height")
+        }
+    }
+}
+
+public struct CharacterNameAndAppearsInWithNestedFragments: GraphQLFragment {
+    public static let fragmentString =
+    "fragment CharacterNameAndAppearsInWithNestedFragments on Character {\n  __typename\n  ...CharacterNameWithNestedAppearsInFragment\n}"
+
+    public static let possibleTypes = ["Human", "Droid"]
+
+    public static let selections: [GraphQLSelection] = [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
+        ]
+
+    public var snapshot: Snapshot
+
+    public init(snapshot: Snapshot) {
+        self.snapshot = snapshot
+    }
+
+    public static func makeHuman(name: String, appearsIn: [Episode?]) -> CharacterNameAndAppearsInWithNestedFragments {
+        return CharacterNameAndAppearsInWithNestedFragments(snapshot: ["__typename": "Human", "name": name, "appearsIn": appearsIn])
+    }
+
+    public static func makeDroid(name: String, appearsIn: [Episode?]) -> CharacterNameAndAppearsInWithNestedFragments {
+        return CharacterNameAndAppearsInWithNestedFragments(snapshot: ["__typename": "Droid", "name": name, "appearsIn": appearsIn])
+    }
+
+    public var __typename: String {
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
+    }
+
+    /// The name of the character
+    public var name: String {
+        get {
+            return snapshot["name"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "name")
+        }
+    }
+
+    /// The movies this character appears in
+    public var appearsIn: [Episode?] {
+        get {
+            return snapshot["appearsIn"]! as! [Episode?]
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "appearsIn")
+        }
+    }
+
+    public var fragments: Fragments {
+        get {
+            return Fragments(snapshot: snapshot)
+        }
+        set {
+            snapshot += newValue.snapshot
+        }
+    }
+
+    public struct Fragments {
+        public var snapshot: Snapshot
+
+        public var characterNameWithNestedAppearsInFragment: CharacterNameWithNestedAppearsInFragment {
+            get {
+                return CharacterNameWithNestedAppearsInFragment(snapshot: snapshot)
+            }
+            set {
+                snapshot += newValue.snapshot
+            }
+        }
+
+        public var characterAppearsIn: CharacterAppearsIn {
+            get {
+                return CharacterAppearsIn(snapshot: snapshot)
+            }
+            set {
+                snapshot += newValue.snapshot
+            }
+        }
+    }
+}
+
+public struct CharacterNameWithNestedAppearsInFragment: GraphQLFragment {
+    public static let fragmentString =
+    "fragment CharacterNameWithNestedAppearsInFragment on Character {\n  __typename\n  name\n  ...CharacterAppearsIn\n}"
+
+    public static let possibleTypes = ["Human", "Droid"]
+
+    public static let selections: [GraphQLSelection] = [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
+        ]
+
+    public var snapshot: Snapshot
+
+    public init(snapshot: Snapshot) {
+        self.snapshot = snapshot
+    }
+
+    public static func makeHuman(name: String, appearsIn: [Episode?]) -> CharacterNameWithNestedAppearsInFragment {
+        return CharacterNameWithNestedAppearsInFragment(snapshot: ["__typename": "Human", "name": name, "appearsIn": appearsIn])
+    }
+
+    public static func makeDroid(name: String, appearsIn: [Episode?]) -> CharacterNameWithNestedAppearsInFragment {
+        return CharacterNameWithNestedAppearsInFragment(snapshot: ["__typename": "Droid", "name": name, "appearsIn": appearsIn])
+    }
+
+    public var __typename: String {
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
+    }
+
+    /// The name of the character
+    public var name: String {
+        get {
+            return snapshot["name"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "name")
+        }
+    }
+
+    /// The movies this character appears in
+    public var appearsIn: [Episode?] {
+        get {
+            return snapshot["appearsIn"]! as! [Episode?]
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "appearsIn")
+        }
+    }
+
+    public var fragments: Fragments {
+        get {
+            return Fragments(snapshot: snapshot)
+        }
+        set {
+            snapshot += newValue.snapshot
+        }
+    }
+
+    public struct Fragments {
+        public var snapshot: Snapshot
+
+        public var characterAppearsIn: CharacterAppearsIn {
+            get {
+                return CharacterAppearsIn(snapshot: snapshot)
+            }
+            set {
+                snapshot += newValue.snapshot
+            }
+        }
+    }
+}
+
+public struct CharacterNameWithInlineFragment: GraphQLFragment {
+    public static let fragmentString =
+    "fragment CharacterNameWithInlineFragment on Character {\n  __typename\n  ... on Human {\n    friends {\n      __typename\n      appearsIn\n    }\n  }\n  ... on Droid {\n    ...CharacterName\n    ...FriendsNames\n  }\n}"
+
+    public static let possibleTypes = ["Human", "Droid"]
+
+    public static let selections: [GraphQLSelection] = [
+        GraphQLTypeCase(
+            variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections],
+            default: [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                ]
+        )
+    ]
+
+    public var snapshot: Snapshot
+
+    public init(snapshot: Snapshot) {
+        self.snapshot = snapshot
+    }
+
+    public static func makeHuman(friends: [AsHuman.Friend?]? = nil) -> CharacterNameWithInlineFragment {
+        return CharacterNameWithInlineFragment(snapshot: ["__typename": "Human", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+    }
+
+    public static func makeDroid(name: String, friends: [AsDroid.Friend?]? = nil) -> CharacterNameWithInlineFragment {
+        return CharacterNameWithInlineFragment(snapshot: ["__typename": "Droid", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+    }
+
+    public var __typename: String {
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
+    }
+
+    public var asHuman: AsHuman? {
+        get {
+            if !AsHuman.possibleTypes.contains(__typename) { return nil }
+            return AsHuman(snapshot: snapshot)
+        }
+        set {
+            guard let newValue = newValue else { return }
+            snapshot = newValue.snapshot
+        }
+    }
+
+    public struct AsHuman: GraphQLSelectionSet {
+        public static let possibleTypes = ["Human"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("friends", type: .list(.object(Friend.selections))),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(friends: [Friend?]? = nil) {
+            self.init(snapshot: ["__typename": "Human", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+        }
+
+        public var __typename: String {
+            get {
+                return snapshot["__typename"]! as! String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "__typename")
+            }
+        }
+
+        /// This human's friends, or an empty list if they have none
+        public var friends: [Friend?]? {
+            get {
+                return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+            }
+            set {
+                snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+            }
+        }
+
+        public struct Friend: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(appearsIn: [Episode?]) -> Friend {
+                return Friend(snapshot: ["__typename": "Human", "appearsIn": appearsIn])
+            }
+
+            public static func makeDroid(appearsIn: [Episode?]) -> Friend {
+                return Friend(snapshot: ["__typename": "Droid", "appearsIn": appearsIn])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The movies this character appears in
+            public var appearsIn: [Episode?] {
+                get {
+                    return snapshot["appearsIn"]! as! [Episode?]
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "appearsIn")
+                }
+            }
+        }
+    }
+
+    public var asDroid: AsDroid? {
+        get {
+            if !AsDroid.possibleTypes.contains(__typename) { return nil }
+            return AsDroid(snapshot: snapshot)
+        }
+        set {
+            guard let newValue = newValue else { return }
+            snapshot = newValue.snapshot
+        }
+    }
+
+    public struct AsDroid: GraphQLSelectionSet {
+        public static let possibleTypes = ["Droid"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("friends", type: .list(.object(Friend.selections))),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(name: String, friends: [Friend?]? = nil) {
+            self.init(snapshot: ["__typename": "Droid", "name": name, "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+        }
+
+        public var __typename: String {
+            get {
+                return snapshot["__typename"]! as! String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "__typename")
+            }
+        }
+
+        /// What others call this droid
+        public var name: String {
+            get {
+                return snapshot["name"]! as! String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "name")
+            }
+        }
+
+        /// This droid's friends, or an empty list if they have none
+        public var friends: [Friend?]? {
+            get {
+                return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+            }
+            set {
+                snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+            }
+        }
+
+        public var fragments: Fragments {
+            get {
+                return Fragments(snapshot: snapshot)
+            }
+            set {
+                snapshot += newValue.snapshot
+            }
+        }
+
+        public struct Fragments {
+            public var snapshot: Snapshot
+
+            public var characterName: CharacterName {
+                get {
+                    return CharacterName(snapshot: snapshot)
+                }
+                set {
+                    snapshot += newValue.snapshot
+                }
+            }
+
+            public var friendsNames: FriendsNames {
+                get {
+                    return FriendsNames(snapshot: snapshot)
+                }
+                set {
+                    snapshot += newValue.snapshot
+                }
+            }
+        }
+
+        public struct Friend: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human", "Droid"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                ]
+
+            public var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public static func makeHuman(name: String) -> Friend {
+                return Friend(snapshot: ["__typename": "Human", "name": name])
+            }
+
+            public static func makeDroid(name: String) -> Friend {
+                return Friend(snapshot: ["__typename": "Droid", "name": name])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// The name of the character
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+        }
+    }
+}
+
+public struct FriendsNames: GraphQLFragment {
+    public static let fragmentString =
+    "fragment FriendsNames on Character {\n  __typename\n  friends {\n    __typename\n    name\n  }\n}"
+
+    public static let possibleTypes = ["Human", "Droid"]
+
+    public static let selections: [GraphQLSelection] = [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("friends", type: .list(.object(Friend.selections))),
+        ]
+
+    public var snapshot: Snapshot
+
+    public init(snapshot: Snapshot) {
+        self.snapshot = snapshot
+    }
+
+    public static func makeHuman(friends: [Friend?]? = nil) -> FriendsNames {
+        return FriendsNames(snapshot: ["__typename": "Human", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+    }
+
+    public static func makeDroid(friends: [Friend?]? = nil) -> FriendsNames {
+        return FriendsNames(snapshot: ["__typename": "Droid", "friends": friends.flatMap { $0.map { $0.flatMap { $0.snapshot } } }])
+    }
+
+    public var __typename: String {
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
+    }
+
+    /// The friends of the character, or an empty list if they have none
+    public var friends: [Friend?]? {
+        get {
+            return (snapshot["friends"] as? [Snapshot?]).flatMap { $0.map { $0.flatMap { Friend(snapshot: $0) } } }
+        }
+        set {
+            snapshot.updateValue(newValue.flatMap { $0.map { $0.flatMap { $0.snapshot } } }, forKey: "friends")
+        }
+    }
+
+    public struct Friend: GraphQLSelectionSet {
+        public static let possibleTypes = ["Human", "Droid"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public static func makeHuman(name: String) -> Friend {
+            return Friend(snapshot: ["__typename": "Human", "name": name])
+        }
+
+        public static func makeDroid(name: String) -> Friend {
+            return Friend(snapshot: ["__typename": "Droid", "name": name])
+        }
+
+        public var __typename: String {
+            get {
+                return snapshot["__typename"]! as! String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "__typename")
+            }
+        }
+
+        /// The name of the character
+        public var name: String {
+            get {
+                return snapshot["name"]! as! String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "name")
+            }
+        }
+    }
+}
+
+public struct CharacterAppearsIn: GraphQLFragment {
+    public static let fragmentString =
+    "fragment CharacterAppearsIn on Character {\n  __typename\n  appearsIn\n}"
+
+    public static let possibleTypes = ["Human", "Droid"]
+
+    public static let selections: [GraphQLSelection] = [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
+        ]
+
+    public var snapshot: Snapshot
+
+    public init(snapshot: Snapshot) {
+        self.snapshot = snapshot
+    }
+
+    public static func makeHuman(appearsIn: [Episode?]) -> CharacterAppearsIn {
+        return CharacterAppearsIn(snapshot: ["__typename": "Human", "appearsIn": appearsIn])
+    }
+
+    public static func makeDroid(appearsIn: [Episode?]) -> CharacterAppearsIn {
+        return CharacterAppearsIn(snapshot: ["__typename": "Droid", "appearsIn": appearsIn])
+    }
+
+    public var __typename: String {
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
+    }
+
+    /// The movies this character appears in
+    public var appearsIn: [Episode?] {
+        get {
+            return snapshot["appearsIn"]! as! [Episode?]
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "appearsIn")
+        }
+    }
+}
+
+public struct HeroDetails: GraphQLFragment {
+    public static let fragmentString =
+    "fragment HeroDetails on Character {\n  __typename\n  name\n  ... on Human {\n    height\n  }\n  ... on Droid {\n    primaryFunction\n  }\n}"
+
+    public static let possibleTypes = ["Human", "Droid"]
+
+    public static let selections: [GraphQLSelection] = [
+        GraphQLTypeCase(
+            variants: ["Human": AsHuman.selections, "Droid": AsDroid.selections],
+            default: [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                ]
+        )
+    ]
+
+    public var snapshot: Snapshot
+
+    public init(snapshot: Snapshot) {
+        self.snapshot = snapshot
+    }
+
+    public static func makeHuman(name: String, height: Double? = nil) -> HeroDetails {
+        return HeroDetails(snapshot: ["__typename": "Human", "name": name, "height": height])
+    }
+
+    public static func makeDroid(name: String, primaryFunction: String? = nil) -> HeroDetails {
+        return HeroDetails(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+    }
+
+    public var __typename: String {
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
+    }
+
+    /// The name of the character
+    public var name: String {
+        get {
+            return snapshot["name"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "name")
+        }
+    }
+
+    public var asHuman: AsHuman? {
+        get {
+            if !AsHuman.possibleTypes.contains(__typename) { return nil }
+            return AsHuman(snapshot: snapshot)
+        }
+        set {
+            guard let newValue = newValue else { return }
+            snapshot = newValue.snapshot
+        }
+    }
+
+    public struct AsHuman: GraphQLSelectionSet {
+        public static let possibleTypes = ["Human"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+            GraphQLField("height", type: .scalar(Double.self)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(name: String, height: Double? = nil) {
+            self.init(snapshot: ["__typename": "Human", "name": name, "height": height])
+        }
+
+        public var __typename: String {
+            get {
+                return snapshot["__typename"]! as! String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "__typename")
+            }
+        }
+
+        /// What this human calls themselves
+        public var name: String {
+            get {
+                return snapshot["name"]! as! String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "name")
+            }
+        }
+
+        /// Height in the preferred unit, default is meters
+        public var height: Double? {
+            get {
+                return snapshot["height"] as? Double
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "height")
+            }
+        }
+    }
+
+    public var asDroid: AsDroid? {
+        get {
+            if !AsDroid.possibleTypes.contains(__typename) { return nil }
+            return AsDroid(snapshot: snapshot)
+        }
+        set {
+            guard let newValue = newValue else { return }
+            snapshot = newValue.snapshot
+        }
+    }
+
+    public struct AsDroid: GraphQLSelectionSet {
+        public static let possibleTypes = ["Droid"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("name", type: .nonNull(.scalar(String.self))),
+            GraphQLField("primaryFunction", type: .scalar(String.self)),
+            ]
+
+        public var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(name: String, primaryFunction: String? = nil) {
+            self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
+        }
+
+        public var __typename: String {
+            get {
+                return snapshot["__typename"]! as! String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "__typename")
+            }
+        }
+
+        /// What others call this droid
+        public var name: String {
+            get {
+                return snapshot["name"]! as! String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "name")
+            }
+        }
+
+        /// This droid's primary function
+        public var primaryFunction: String? {
+            get {
+                return snapshot["primaryFunction"] as? String
+            }
+            set {
+                snapshot.updateValue(newValue, forKey: "primaryFunction")
+            }
+        }
+    }
 }
 
 public struct DroidDetails: GraphQLFragment {
-  public static let fragmentString =
+    public static let fragmentString =
     "fragment DroidDetails on Droid {\n  __typename\n  name\n  primaryFunction\n}"
 
-  public static let possibleTypes = ["Droid"]
+    public static let possibleTypes = ["Droid"]
 
-  public static let selections: [GraphQLSelection] = [
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("name", type: .nonNull(.scalar(String.self))),
-    GraphQLField("primaryFunction", type: .scalar(String.self)),
-  ]
+    public static let selections: [GraphQLSelection] = [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        GraphQLField("primaryFunction", type: .scalar(String.self)),
+        ]
 
-  public var snapshot: Snapshot
+    public var snapshot: Snapshot
 
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public init(name: String, primaryFunction: String? = nil) {
-    self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
+    public init(snapshot: Snapshot) {
+        self.snapshot = snapshot
     }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
 
-  /// What others call this droid
-  public var name: String {
-    get {
-      return snapshot["name"]! as! String
+    public init(name: String, primaryFunction: String? = nil) {
+        self.init(snapshot: ["__typename": "Droid", "name": name, "primaryFunction": primaryFunction])
     }
-    set {
-      snapshot.updateValue(newValue, forKey: "name")
-    }
-  }
 
-  /// This droid's primary function
-  public var primaryFunction: String? {
-    get {
-      return snapshot["primaryFunction"] as? String
+    public var __typename: String {
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
     }
-    set {
-      snapshot.updateValue(newValue, forKey: "primaryFunction")
+
+    /// What others call this droid
+    public var name: String {
+        get {
+            return snapshot["name"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "name")
+        }
     }
-  }
+
+    /// This droid's primary function
+    public var primaryFunction: String? {
+        get {
+            return snapshot["primaryFunction"] as? String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "primaryFunction")
+        }
+    }
 }
 
 public struct CharacterName: GraphQLFragment {
-  public static let fragmentString =
+    public static let fragmentString =
     "fragment CharacterName on Character {\n  __typename\n  name\n}"
 
-  public static let possibleTypes = ["Human", "Droid"]
+    public static let possibleTypes = ["Human", "Droid"]
 
-  public static let selections: [GraphQLSelection] = [
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("name", type: .nonNull(.scalar(String.self))),
-  ]
+    public static let selections: [GraphQLSelection] = [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        ]
 
-  public var snapshot: Snapshot
+    public var snapshot: Snapshot
 
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public static func makeHuman(name: String) -> CharacterName {
-    return CharacterName(snapshot: ["__typename": "Human", "name": name])
-  }
-
-  public static func makeDroid(name: String) -> CharacterName {
-    return CharacterName(snapshot: ["__typename": "Droid", "name": name])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
+    public init(snapshot: Snapshot) {
+        self.snapshot = snapshot
     }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
 
-  /// The name of the character
-  public var name: String {
-    get {
-      return snapshot["name"]! as! String
+    public static func makeHuman(name: String) -> CharacterName {
+        return CharacterName(snapshot: ["__typename": "Human", "name": name])
     }
-    set {
-      snapshot.updateValue(newValue, forKey: "name")
+
+    public static func makeDroid(name: String) -> CharacterName {
+        return CharacterName(snapshot: ["__typename": "Droid", "name": name])
     }
-  }
+
+    public var __typename: String {
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
+    }
+
+    /// The name of the character
+    public var name: String {
+        get {
+            return snapshot["name"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "name")
+        }
+    }
 }
 
 public struct CharacterNameAndAppearsIn: GraphQLFragment {
-  public static let fragmentString =
+    public static let fragmentString =
     "fragment CharacterNameAndAppearsIn on Character {\n  __typename\n  name\n  appearsIn\n}"
 
-  public static let possibleTypes = ["Human", "Droid"]
+    public static let possibleTypes = ["Human", "Droid"]
 
-  public static let selections: [GraphQLSelection] = [
-    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-    GraphQLField("name", type: .nonNull(.scalar(String.self))),
-    GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
-  ]
+    public static let selections: [GraphQLSelection] = [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("name", type: .nonNull(.scalar(String.self))),
+        GraphQLField("appearsIn", type: .nonNull(.list(.scalar(Episode.self)))),
+        ]
 
-  public var snapshot: Snapshot
+    public var snapshot: Snapshot
 
-  public init(snapshot: Snapshot) {
-    self.snapshot = snapshot
-  }
-
-  public static func makeHuman(name: String, appearsIn: [Episode?]) -> CharacterNameAndAppearsIn {
-    return CharacterNameAndAppearsIn(snapshot: ["__typename": "Human", "name": name, "appearsIn": appearsIn])
-  }
-
-  public static func makeDroid(name: String, appearsIn: [Episode?]) -> CharacterNameAndAppearsIn {
-    return CharacterNameAndAppearsIn(snapshot: ["__typename": "Droid", "name": name, "appearsIn": appearsIn])
-  }
-
-  public var __typename: String {
-    get {
-      return snapshot["__typename"]! as! String
+    public init(snapshot: Snapshot) {
+        self.snapshot = snapshot
     }
-    set {
-      snapshot.updateValue(newValue, forKey: "__typename")
-    }
-  }
 
-  /// The name of the character
-  public var name: String {
-    get {
-      return snapshot["name"]! as! String
+    public static func makeHuman(name: String, appearsIn: [Episode?]) -> CharacterNameAndAppearsIn {
+        return CharacterNameAndAppearsIn(snapshot: ["__typename": "Human", "name": name, "appearsIn": appearsIn])
     }
-    set {
-      snapshot.updateValue(newValue, forKey: "name")
-    }
-  }
 
-  /// The movies this character appears in
-  public var appearsIn: [Episode?] {
-    get {
-      return snapshot["appearsIn"]! as! [Episode?]
+    public static func makeDroid(name: String, appearsIn: [Episode?]) -> CharacterNameAndAppearsIn {
+        return CharacterNameAndAppearsIn(snapshot: ["__typename": "Droid", "name": name, "appearsIn": appearsIn])
     }
-    set {
-      snapshot.updateValue(newValue, forKey: "appearsIn")
+
+    public var __typename: String {
+        get {
+            return snapshot["__typename"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "__typename")
+        }
     }
-  }
+
+    /// The name of the character
+    public var name: String {
+        get {
+            return snapshot["name"]! as! String
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "name")
+        }
+    }
+
+    /// The movies this character appears in
+    public var appearsIn: [Episode?] {
+        get {
+            return snapshot["appearsIn"]! as! [Episode?]
+        }
+        set {
+            snapshot.updateValue(newValue, forKey: "appearsIn")
+        }
+    }
+}
+
+public final class HumanFriendsFilteredByIdQuery: GraphQLQuery {
+    public static var operationString = "query HumanFriendsFilteredById($id: ID!, $friendId: ID = null) {\n  human(id: $id) {\n    __typename\n    name\n    mass\n    friendsFilteredById(id: $friendId) {\n      __typename\n      id\n      name\n    }\n  }\n}"
+
+    public var id: GraphQLID
+    public var friendId: GraphQLID?
+
+    public init(id: GraphQLID, friendId: GraphQLID? = nil) {
+        self.id = id
+        self.friendId = friendId
+    }
+
+    public var variables: GraphQLMap? {
+        return ["id": id, "friendId": friendId]
+    }
+
+    public struct Data: GraphQLSelectionSet {
+        public static let possibleTypes = ["Query"]
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("human", arguments: ["id": GraphQLVariable("id")], type: .object(Human.selections)),
+            ]
+
+        public private(set) var snapshot: Snapshot
+
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public init(human: Human? = nil) {
+            self.init(snapshot: ["__typename": "Query", "human": human.flatMap { (value: Human) -> Snapshot in value.snapshot }])
+        }
+
+        public var human: Human? {
+            get {
+                return (snapshot["human"] as? Snapshot).flatMap { Human(snapshot: $0) }
+            }
+            set {
+                snapshot.updateValue(newValue?.snapshot, forKey: "human")
+            }
+        }
+
+        public struct Human: GraphQLSelectionSet {
+            public static let possibleTypes = ["Human"]
+
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                GraphQLField("mass", type: .scalar(Double.self)),
+                GraphQLField("friendsFilteredById", arguments: ["id": GraphQLVariable("friendId")], type: .list(.object(FriendsFilteredById.selections))),
+                ]
+
+            public private(set) var snapshot: Snapshot
+
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+
+            public init(name: String, mass: Double? = nil, friendsFilteredById: [FriendsFilteredById?]? = nil) {
+                self.init(snapshot: ["__typename": "Human", "name": name, "mass": mass, "friendsFilteredById": friendsFilteredById.flatMap { (value: [FriendsFilteredById?]) -> [Snapshot?] in value.map { (value: FriendsFilteredById?) -> Snapshot? in value.flatMap { (value: FriendsFilteredById) -> Snapshot in value.snapshot } } }])
+            }
+
+            public var __typename: String {
+                get {
+                    return snapshot["__typename"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "__typename")
+                }
+            }
+
+            /// What this human calls themselves
+            public var name: String {
+                get {
+                    return snapshot["name"]! as! String
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "name")
+                }
+            }
+
+            /// Mass in kilograms, or null if unknown
+            public var mass: Double? {
+                get {
+                    return snapshot["mass"] as? Double
+                }
+                set {
+                    snapshot.updateValue(newValue, forKey: "mass")
+                }
+            }
+
+            /// The friends of this human filtered by Id, or an empty list if they have none
+            public var friendsFilteredById: [FriendsFilteredById?]? {
+                get {
+                    return (snapshot["friendsFilteredById"] as? [Snapshot?]).flatMap { (value: [Snapshot?]) -> [FriendsFilteredById?] in value.map { (value: Snapshot?) -> FriendsFilteredById? in value.flatMap { (value: Snapshot) -> FriendsFilteredById in FriendsFilteredById(snapshot: value) } } }
+                }
+                set {
+                    snapshot.updateValue(newValue.flatMap { (value: [FriendsFilteredById?]) -> [Snapshot?] in value.map { (value: FriendsFilteredById?) -> Snapshot? in value.flatMap { (value: FriendsFilteredById) -> Snapshot in value.snapshot } } }, forKey: "friendsFilteredById")
+                }
+            }
+
+            public struct FriendsFilteredById: GraphQLSelectionSet {
+                public static let possibleTypes = ["Human", "Droid"]
+
+                public static let selections: [GraphQLSelection] = [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+                    GraphQLField("name", type: .nonNull(.scalar(String.self))),
+                    ]
+
+                public private(set) var snapshot: Snapshot
+
+                public init(snapshot: Snapshot) {
+                    self.snapshot = snapshot
+                }
+
+                public static func makeHuman(id: GraphQLID, name: String) -> FriendsFilteredById {
+                    return FriendsFilteredById(snapshot: ["__typename": "Human", "id": id, "name": name])
+                }
+
+                public static func makeDroid(id: GraphQLID, name: String) -> FriendsFilteredById {
+                    return FriendsFilteredById(snapshot: ["__typename": "Droid", "id": id, "name": name])
+                }
+
+                public var __typename: String {
+                    get {
+                        return snapshot["__typename"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "__typename")
+                    }
+                }
+
+                /// The ID of the character
+                public var id: GraphQLID {
+                    get {
+                        return snapshot["id"]! as! GraphQLID
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "id")
+                    }
+                }
+
+                /// The name of the character
+                public var name: String {
+                    get {
+                        return snapshot["name"]! as! String
+                    }
+                    set {
+                        snapshot.updateValue(newValue, forKey: "name")
+                    }
+                }
+            }
+        }
+    }
 }

--- a/StarWarsAPI/HumanFriendsFilteredById.graphql
+++ b/StarWarsAPI/HumanFriendsFilteredById.graphql
@@ -1,0 +1,10 @@
+query HumanFriendsFilteredById($id: ID!, $friendId: ID = null) {
+  human(id: $id) {
+    name
+    mass
+    friendsFilteredById(id: $friendId) {
+      id
+      name
+    }
+  }
+}

--- a/StarWarsAPI/StarWarsAPI.h
+++ b/StarWarsAPI/StarWarsAPI.h
@@ -1,12 +1,4 @@
-//
-//  StarWarsAPI.h
-//  StarWarsAPI
-//
-//  Created by Dubal, Rohan on 9/20/18.
-//  Copyright © 2018 Amazon Web Services. All rights reserved.
-//
-
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for StarWarsAPI.
 FOUNDATION_EXPORT double StarWarsAPIVersionNumber;
@@ -15,5 +7,3 @@ FOUNDATION_EXPORT double StarWarsAPIVersionNumber;
 FOUNDATION_EXPORT const unsigned char StarWarsAPIVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <StarWarsAPI/PublicHeader.h>
-
-

--- a/StarWarsAPI/schema.json
+++ b/StarWarsAPI/schema.json
@@ -294,6 +294,33 @@
               "deprecationReason": null
             },
             {
+              "name": "friendsFilteredById",
+              "description": "The friends of the character filtered by Id, or an empty list if they have none",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Character",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "friendsConnection",
               "description": "The friends of the character exposed as a connection with edges",
               "args": [
@@ -746,6 +773,33 @@
               "deprecationReason": null
             },
             {
+              "name": "friendsFilteredById",
+              "description": "The friends of this human filtered by Id, or an empty list if they have none",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Character",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "friendsConnection",
               "description": "The friends of the human exposed as a connection with edges",
               "args": [
@@ -998,6 +1052,33 @@
               "name": "friends",
               "description": "This droid's friends, or an empty list if they have none",
               "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Character",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "friendsFilteredById",
+              "description": "The friends of the droid filtered by Id, or an empty list if they have none",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
               "type": {
                 "kind": "LIST",
                 "name": null,


### PR DESCRIPTION
- Fix optimistic update tests to wait for optimistic update to complete before
  fetching
- Added unit test helper for some utility functions
- Ported Apollo's CachePersistenceTests from their HEAD
- Added new field, 'friendsFilteredById', to allow easier testing of arguments
  with arbitrary string constructions
- Added persistence tests for arguments with dots

*Issue #, if available:*

- #110 
- #165 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
