### PR TITLE
Invoke mutation result handlers on specified queue instead of always …

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		FA0C12C121CD3BB200B438CB /* BasicAWSAPIKeyAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0C12C021CD3BB200B438CB /* BasicAWSAPIKeyAuthProvider.swift */; };
 		FA1A620C21E6533A00AA54D0 /* AWSAppSyncRetryHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1A620B21E6533A00AA54D0 /* AWSAppSyncRetryHandlerTests.swift */; };
 		FA2B4598221DDF2C00F68E6C /* CachePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2B4597221DDF2C00F68E6C /* CachePersistenceTests.swift */; };
+		FA2B459A221F436400F68E6C /* MutationQueuePerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2B4599221F436400F68E6C /* MutationQueuePerformanceTests.swift */; };
 		FA38636E21DD8FF200DBA2BC /* MutationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA38636D21DD8FF200DBA2BC /* MutationQueueTests.swift */; };
 		FA3E128121D5259800F2D19A /* AWSAppSyncClientConfigurationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3E128021D5259800F2D19A /* AWSAppSyncClientConfigurationError.swift */; };
 		FA3E128321D5290900F2D19A /* AWSAppSyncClientInfoError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3E128221D5290900F2D19A /* AWSAppSyncClientInfoError.swift */; };
@@ -444,6 +445,7 @@
 		FA0C12C721CD96BF00B438CB /* AWSAppSyncClientConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAppSyncClientConfigurationTests.swift; sourceTree = "<group>"; };
 		FA1A620B21E6533A00AA54D0 /* AWSAppSyncRetryHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAppSyncRetryHandlerTests.swift; sourceTree = "<group>"; };
 		FA2B4597221DDF2C00F68E6C /* CachePersistenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CachePersistenceTests.swift; sourceTree = "<group>"; };
+		FA2B4599221F436400F68E6C /* MutationQueuePerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationQueuePerformanceTests.swift; sourceTree = "<group>"; };
 		FA30F363219B353800B92938 /* SubscriptionStressTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionStressTestHelper.swift; sourceTree = "<group>"; };
 		FA38636D21DD8FF200DBA2BC /* MutationQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationQueueTests.swift; sourceTree = "<group>"; };
 		FA3E128021D5259800F2D19A /* AWSAppSyncClientConfigurationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAppSyncClientConfigurationError.swift; sourceTree = "<group>"; };
@@ -862,6 +864,7 @@
 				FA8C62B521D6E3AA00FF9924 /* Info.plist */,
 				FA005959221222D800BFBD13 /* MutationOptimisticUpdateTests.swift */,
 				FA38636D21DD8FF200DBA2BC /* MutationQueueTests.swift */,
+				FA2B4599221F436400F68E6C /* MutationQueuePerformanceTests.swift */,
 				FA88834621E3D05800DEBCB3 /* ReachabilityChangeNotifierTests.swift */,
 				FAD17C7021C2ABEA008D116C /* SubscriptionMessagesQueueTests.swift */,
 				FAD17C6821C16E58008D116C /* SyncStrategyTests.swift */,
@@ -1604,6 +1607,7 @@
 				FA88834721E3D05800DEBCB3 /* ReachabilityChangeNotifierTests.swift in Sources */,
 				FAE7948721D6EB290032D37F /* AWSAppSyncClientConfigurationTests.swift in Sources */,
 				FAC3E712220900A20037813E /* AWSAppSyncCacheConfigurationMigrationTests.swift in Sources */,
+				FA2B459A221F436400F68E6C /* MutationQueuePerformanceTests.swift in Sources */,
 				FAE7948621D6EAE70032D37F /* Foundation+UtilsTests.swift in Sources */,
 				FABD707122050EDF00C99B47 /* AWSAppSyncClientConfigurationTestsWithDatabaseURL.swift in Sources */,
 				FABD70752205101600C99B47 /* AWSAppSyncClientInfoTests.swift in Sources */,

--- a/AWSAppSyncClient/AWSAppSyncClient.swift
+++ b/AWSAppSyncClient/AWSAppSyncClient.swift
@@ -15,12 +15,6 @@ public typealias OptimisticResponseBlock = (ApolloStore.ReadWriteTransaction?) -
 
 public typealias MutationConflictHandler<Mutation: GraphQLMutation> = (_ serverState: Snapshot?, _ taskCompletionSource: AWSTaskCompletionSource<Mutation>?, _ resultHandler: OperationResultHandler<Mutation>?) -> Void
 
-enum AWSAppSyncGraphQLOperation {
-    case mutation
-    case query
-    case subscription
-}
-
 internal let NoOpOperationString = "No-op"
 
 public struct AWSAppSyncSubscriptionError: Error, LocalizedError {
@@ -97,7 +91,6 @@ public class AWSAppSyncClient {
         self.mutationQueue = AWSPerformMutationQueue(
             appSyncClient: self,
             networkClient: httpTransport!,
-            handlerQueue: .main,
             reachabiltyChangeNotifier: NetworkReachabilityNotifier.shared,
             cacheFileURL: appSyncConfig.cacheConfiguration?.offlineMutations)
 
@@ -213,7 +206,9 @@ public class AWSAppSyncClient {
         return mutationQueue.add(
             mutation,
             mutationConflictHandler: conflictResolutionBlock,
-            mutationResultHandler: resultHandler)
+            mutationResultHandler: resultHandler,
+            handlerQueue: queue
+        )
     }
 
     internal final class EmptySubscription: GraphQLSubscription {

--- a/AWSAppSyncClient/Internal/AWSMutationCache.swift
+++ b/AWSAppSyncClient/Internal/AWSMutationCache.swift
@@ -86,15 +86,9 @@ public final class AWSMutationCache {
         }
     }
 
-    internal func deleteMutationRecord(record: AWSAppSyncMutationRecord) -> Promise<Void> {
-        return Promise {
-            let sqlRecord = mutationRecords.filter(recordIdentifier == record.recordIdentitifer)
-            try db.run(sqlRecord.delete())
-        }
-    }
-
     internal func deleteMutationRecord(withIdentifier identifier: String) -> Promise<Void> {
         return Promise {
+            AppSyncLog.verbose("Deleting \(identifier)")
             let sqlRecord = mutationRecords.filter(recordIdentifier == identifier)
             try db.run(sqlRecord.delete())
         }

--- a/AWSAppSyncClient/Internal/AWSPerformMutationQueue.swift
+++ b/AWSAppSyncClient/Internal/AWSPerformMutationQueue.swift
@@ -13,18 +13,15 @@ final class AWSPerformMutationQueue {
     private let persistentCache: AWSMutationCache?
 
     private let operationQueue: OperationQueue
-    private let handlerQueue: DispatchQueue
 
     init(
         appSyncClient: AWSAppSyncClient,
         networkClient: AWSNetworkTransport,
-        handlerQueue: DispatchQueue = .main,
         reachabiltyChangeNotifier: NetworkReachabilityNotifier?,
         cacheFileURL: URL? = nil) {
 
         self.appSyncClient = appSyncClient
         self.networkClient = networkClient
-        self.handlerQueue = handlerQueue
 
         self.operationQueue = OperationQueue()
         self.operationQueue.name = "com.amazonaws.service.appsync.MutationQueue"
@@ -58,7 +55,8 @@ final class AWSPerformMutationQueue {
     func add<Mutation: GraphQLMutation>(
         _ mutation: Mutation,
         mutationConflictHandler: MutationConflictHandler<Mutation>?,
-        mutationResultHandler: OperationResultHandler<Mutation>?) -> Cancellable {
+        mutationResultHandler: OperationResultHandler<Mutation>?,
+        handlerQueue: DispatchQueue) -> Cancellable {
 
         let offlineMutation: AWSAppSyncMutationRecord?
         do {
@@ -115,7 +113,7 @@ final class AWSPerformMutationQueue {
                 let operation = AWSPerformOfflineMutationOperation(
                     appSyncClient: appSyncClient,
                     networkClient: networkClient,
-                    handlerQueue: handlerQueue,
+                    handlerQueue: .main,
                     mutation: mutation)
 
                 operation.operationCompletionBlock = { [weak self] operation, error in

--- a/AWSAppSyncUnitTests/MutationQueuePerformanceTests.swift
+++ b/AWSAppSyncUnitTests/MutationQueuePerformanceTests.swift
@@ -1,0 +1,175 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Amazon Software License
+// http://aws.amazon.com/asl/
+//
+
+import XCTest
+@testable import AWSAppSync
+@testable import AWSAppSyncTestCommon
+
+class MutationQueuePerformanceTests: XCTestCase {
+    var cacheConfiguration: AWSAppSyncCacheConfiguration!
+
+    // Setting this up as a concurrent queue for maximum throughput on the result side--we're interested in measuring
+    // the performance of the enqueue & perform side up through invocation of the handler
+    let mutationHandlerQueue = DispatchQueue(label: "com.amazonaws.MutationQueuePerformanceTests",
+                                             attributes: .concurrent)
+
+    override func setUp() {
+        let tempDir = FileManager.default.temporaryDirectory
+        let rootDirectory = tempDir.appendingPathComponent("MutationQueuePerformanceTests-\(UUID().uuidString)")
+        cacheConfiguration = try! AWSAppSyncCacheConfiguration(withRootDirectory: rootDirectory)
+    }
+
+    override func tearDown() {
+        MockReachabilityProvidingFactory.clearShared()
+        NetworkReachabilityNotifier.clearShared()
+    }
+
+    func test50ConcurrentlyPerformedMutationsWithBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 50,
+                                           performConcurrently: true,
+                                           cacheConfiguration: cacheConfiguration)
+    }
+
+    func test50SeriallyPerformedMutationsWithBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 50,
+                                           performConcurrently: false,
+                                           cacheConfiguration: cacheConfiguration)
+    }
+
+    func test100ConcurrentlyPerformedMutationsWithBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 100,
+                                           performConcurrently: true,
+                                           cacheConfiguration: cacheConfiguration)
+    }
+
+    func test100SeriallyPerformedMutationsWithBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 100,
+                                           performConcurrently: false,
+                                           cacheConfiguration: cacheConfiguration)
+    }
+
+    func test500ConcurrentlyPerformedMutationsWithBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 500,
+                                           performConcurrently: true,
+                                           cacheConfiguration: cacheConfiguration)
+    }
+
+    func test500SeriallyPerformedMutationsWithBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 500,
+                                           performConcurrently: false,
+                                           cacheConfiguration: cacheConfiguration)
+    }
+
+    func test1000ConcurrentlyPerformedMutationsWithBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 1000,
+                                           performConcurrently: true,
+                                           cacheConfiguration: cacheConfiguration)
+    }
+
+    func test1000SeriallyPerformedMutationsWithBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 1000,
+                                           performConcurrently: false,
+                                           cacheConfiguration: cacheConfiguration)
+    }
+
+    func test50ConcurrentlyPerformedMutationsWithoutBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 50,
+                                           performConcurrently: true,
+                                           cacheConfiguration: nil)
+    }
+
+    func test50SeriallyPerformedMutationsWithoutBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 50,
+                                           performConcurrently: false,
+                                           cacheConfiguration: nil)
+    }
+
+    func test100ConcurrentlyPerformedMutationsWithoutBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 100,
+                                           performConcurrently: true,
+                                           cacheConfiguration: nil)
+    }
+
+    func test100SeriallyPerformedMutationsWithoutBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 100,
+                                           performConcurrently: false,
+                                           cacheConfiguration: nil)
+    }
+
+    func test500ConcurrentlyPerformedMutationsWithoutBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 500,
+                                           performConcurrently: true,
+                                           cacheConfiguration: nil)
+    }
+
+    func test500SeriallyPerformedMutationsWithoutBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 500,
+                                           performConcurrently: false,
+                                           cacheConfiguration: nil)
+    }
+
+    func test1000ConcurrentlyPerformedMutationsWithoutBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 1000,
+                                           performConcurrently: true,
+                                           cacheConfiguration: nil)
+    }
+
+    func test1000SeriallyPerformedMutationsWithoutBackingDatabase() throws {
+        try doMutationQueuePerformanceTest(numberOfMutations: 1000,
+                                           performConcurrently: false,
+                                           cacheConfiguration: nil)
+    }
+
+    // MARK: - Utility methods
+    func doMutationQueuePerformanceTest(numberOfMutations: Int,
+                                        performConcurrently: Bool,
+                                        cacheConfiguration: AWSAppSyncCacheConfiguration?) throws {
+        let mockHTTPTransport = MockAWSNetworkTransport()
+        mockHTTPTransport.sendOperationHandlerResponseBody = makeTestMutationWithoutParametersResponseBody(withValue: true)
+
+        let appSyncClient = try UnitTestHelpers.makeAppSyncClient(using: mockHTTPTransport,
+                                                                  cacheConfiguration: cacheConfiguration)
+
+        let operationQueue = OperationQueue()
+        operationQueue.name = "Perform mutations"
+
+        operationQueue.maxConcurrentOperationCount =
+            performConcurrently
+            ? OperationQueue.defaultMaxConcurrentOperationCount
+            : 1
+
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: false) {
+            operationQueue.isSuspended = true
+
+            for _ in 0 ..< numberOfMutations {
+                let mutation = TestMutationWithoutParametersMutation()
+
+                operationQueue.addOperation {
+                    let semaphore = DispatchSemaphore(value: numberOfMutations)
+                    appSyncClient.perform(mutation: mutation, queue: self.mutationHandlerQueue) { _, _ in
+                        semaphore.signal()
+                    }
+                    let _ = semaphore.wait(timeout: DispatchTime.now() + .seconds(60))
+                }
+            }
+
+            // Sanity check
+            XCTAssertEqual(operationQueue.operationCount, numberOfMutations)
+
+            startMeasuring()
+            operationQueue.isSuspended = false
+            operationQueue.waitUntilAllOperationsAreFinished()
+
+            // Sanity check
+            XCTAssertEqual(operationQueue.operationCount, 0)
+        }
+    }
+
+    func makeTestMutationWithoutParametersResponseBody(withValue value: Bool) -> JSONObject {
+        return ["data": ["testMutationWithoutParameters": value]]
+    }
+
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The AWS AppSync SDK for iOS enables you to access your AWS AppSync backend and p
 
 ### Bug fixes
 
-- Fix a bug where queries with dots (`"."`) in the arguments were not being properly cached ([Issue #110](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/110), [#165](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/165))
+- Fixed a bug where queries with dots (`"."`) in the arguments were not being properly cached ([Issue #110](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/110), [#165](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/165))
+- `AWSAppSyncClient.perform(mutation:queue:optimisticUpdate:conflictResolutionBlock:resultHandler:)` now properly invokes its result handler callbacks on the supplied `queue` instead of always using `DispatchQueue.main`
 
 ## 2.10.1
 


### PR DESCRIPTION
…main

- Removed unused AWSAppSyncGraphQLOperation enum
- Added mutation queue performance tests (#173)
- Removed dead code for handler queue assignment in `AWSPerformMutationQueue` 

*Issue #, if available:*
#173 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
