### PR TITLE
Fixed incorrect AWSCore dependency version in podspec

### DIFF
--- a/AWSAppSync.podspec
+++ b/AWSAppSync.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.ios.deployment_target = '9.0'
   s.swift_version = '4.2'
-  s.dependency 'AWSCore', '~> 2.8.0'
+  s.dependency 'AWSCore', '~> 2.9.0'
   s.dependency 'SQLite.swift', '0.11.5'
   s.dependency 'ReachabilitySwift', '~> 4.3.0'
   s.source_files = 'AWSAppSyncClient/AWSAppSync.h', 'AWSAppSyncClient/*.swift', 'AWSAppSyncClient/Internal/*.swift', 'AWSAppSyncClient/Apollo/Sources/Apollo/*.swift', 'AWSAppSyncClient/MQTTSDK/*.{h,m}', 'AWSAppSyncClient/MQTTSDK/MQTTSDK/*.{h,m}', 'AWSAppSyncClient/MQTTSDK/SocketRocket/*.{h,m}', 'AWSAppSyncClient/Internal/*.{h,m}'

--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		FA1A620C21E6533A00AA54D0 /* AWSAppSyncRetryHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1A620B21E6533A00AA54D0 /* AWSAppSyncRetryHandlerTests.swift */; };
 		FA2B4598221DDF2C00F68E6C /* CachePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2B4597221DDF2C00F68E6C /* CachePersistenceTests.swift */; };
 		FA2B459A221F436400F68E6C /* MutationQueuePerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2B4599221F436400F68E6C /* MutationQueuePerformanceTests.swift */; };
+		FA2BE607222746EC0036FCD9 /* AWSAppSyncClientLogFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2BE606222746EC0036FCD9 /* AWSAppSyncClientLogFormatter.swift */; };
 		FA38636E21DD8FF200DBA2BC /* MutationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA38636D21DD8FF200DBA2BC /* MutationQueueTests.swift */; };
 		FA3E128121D5259800F2D19A /* AWSAppSyncClientConfigurationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3E128021D5259800F2D19A /* AWSAppSyncClientConfigurationError.swift */; };
 		FA3E128321D5290900F2D19A /* AWSAppSyncClientInfoError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3E128221D5290900F2D19A /* AWSAppSyncClientInfoError.swift */; };
@@ -446,6 +447,7 @@
 		FA1A620B21E6533A00AA54D0 /* AWSAppSyncRetryHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAppSyncRetryHandlerTests.swift; sourceTree = "<group>"; };
 		FA2B4597221DDF2C00F68E6C /* CachePersistenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CachePersistenceTests.swift; sourceTree = "<group>"; };
 		FA2B4599221F436400F68E6C /* MutationQueuePerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationQueuePerformanceTests.swift; sourceTree = "<group>"; };
+		FA2BE606222746EC0036FCD9 /* AWSAppSyncClientLogFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAppSyncClientLogFormatter.swift; sourceTree = "<group>"; };
 		FA30F363219B353800B92938 /* SubscriptionStressTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionStressTestHelper.swift; sourceTree = "<group>"; };
 		FA38636D21DD8FF200DBA2BC /* MutationQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutationQueueTests.swift; sourceTree = "<group>"; };
 		FA3E128021D5259800F2D19A /* AWSAppSyncClientConfigurationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAppSyncClientConfigurationError.swift; sourceTree = "<group>"; };
@@ -767,6 +769,7 @@
 				CCEF79DC21DE7EED004AD64D /* AWSAppSyncClientError.swift */,
 				FABD707222050FD100C99B47 /* AWSAppSyncClientInfo.swift */,
 				FA3E128221D5290900F2D19A /* AWSAppSyncClientInfoError.swift */,
+				FA2BE606222746EC0036FCD9 /* AWSAppSyncClientLogFormatter.swift */,
 				178B31051FCDB34100EA4619 /* AWSAppSyncClientS3ObjectsExtensions.swift */,
 				FA88834421E3C2D300DEBCB3 /* AWSAppSyncConnection.swift */,
 				17915B041F5F106600C4B73C /* AWSAppSyncHTTPNetworkTransport.swift */,
@@ -1527,6 +1530,7 @@
 				17E009C01FCAB234005031DB /* InMemoryNormalizedCache.swift in Sources */,
 				CC96F8AB21BAF68300446EBD /* AWSRequestBuilder.swift in Sources */,
 				17E009CA1FCAB234005031DB /* GraphQLExecutor.swift in Sources */,
+				FA2BE607222746EC0036FCD9 /* AWSAppSyncClientLogFormatter.swift in Sources */,
 				17E009DC1FCAB234005031DB /* ApolloClient.swift in Sources */,
 				17E009CE1FCAB234005031DB /* GraphQLError.swift in Sources */,
 				17D2C2071F6F44A3006C6818 /* AWSOfflineMutation.swift in Sources */,

--- a/AWSAppSyncClient/AWSAppSyncClient.swift
+++ b/AWSAppSyncClient/AWSAppSyncClient.swift
@@ -71,6 +71,9 @@ public class AWSAppSyncClient {
 
     init(appSyncConfig: AWSAppSyncClientConfiguration,
          reachabilityFactory: NetworkReachabilityProvidingFactory.Type? = nil) throws {
+
+        AppSyncLog.info("Initializing AppSyncClient")
+
         self.autoSubmitOfflineMutations = appSyncConfig.autoSubmitOfflineMutations
         self.store = appSyncConfig.store
         self.appSyncMQTTClient.allowCellularAccess = appSyncConfig.allowsCellularAccess
@@ -102,6 +105,7 @@ public class AWSAppSyncClient {
     }
 
     deinit {
+        AppSyncLog.info("Releasing AppSyncClient")
         NetworkReachabilityNotifier.clearShared()
     }
 
@@ -132,7 +136,7 @@ public class AWSAppSyncClient {
     ///   - error: An error that indicates why the fetch failed, or `nil` if the fetch was succesful.
     /// - Returns: An object that can be used to cancel an in progress fetch.
     @discardableResult public func fetch<Query: GraphQLQuery>(query: Query, cachePolicy: CachePolicy = .returnCacheDataElseFetch, queue: DispatchQueue = DispatchQueue.main, resultHandler: OperationResultHandler<Query>? = nil) -> Cancellable {
-        AppSyncLog.verbose("fetch: \(query)")
+        AppSyncLog.verbose("Fetching: \(query)")
         return apolloClient!.fetch(query: query, cachePolicy: cachePolicy, queue: queue, resultHandler: resultHandler)
     }
 

--- a/AWSAppSyncClient/AWSAppSyncClientLogFormatter.swift
+++ b/AWSAppSyncClient/AWSAppSyncClientLogFormatter.swift
@@ -1,0 +1,47 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Amazon Software License
+// http://aws.amazon.com/asl/
+//
+
+import Foundation
+
+public final class AWSAppSyncClientLogFormatter: NSObject, AWSDDLogFormatter {
+
+    static let dateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        // 2019-02-27 15:09:34.624-0800
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSZ"
+        return dateFormatter
+    }()
+
+    public func format(message logMessage: AWSDDLogMessage) -> String? {
+        let logLevelPrefix: String
+        switch logMessage.flag {
+        case .error:
+            logLevelPrefix = "E"
+        case .warning:
+            logLevelPrefix = "W"
+        case .info:
+            logLevelPrefix = "I"
+        case .debug:
+            logLevelPrefix = "D"
+        default:
+            logLevelPrefix = "V"
+        }
+
+        let date = AWSAppSyncClientLogFormatter.dateFormatter.string(from: logMessage.timestamp)
+        let file = AWSDDExtractFileNameWithoutExtension(logMessage.file, false) ?? "(no file)"
+        let line = String(describing: logMessage.line)
+
+        var sourceSection = file
+        if let function = logMessage.function {
+            sourceSection += ".\(function)"
+        }
+        sourceSection += ", L\(line)"
+
+        let message = "\(date) [\(logLevelPrefix) \(sourceSection)] \(logMessage.message)"
+        return message
+    }
+
+}

--- a/AWSAppSyncClient/AWSAppSyncClientS3ObjectsExtensions.swift
+++ b/AWSAppSyncClient/AWSAppSyncClientS3ObjectsExtensions.swift
@@ -11,7 +11,6 @@ extension AWSAppSyncClient {
         operation: Operation,
         s3Object: InternalS3ObjectDetails,
         conflictResolutionBlock: MutationConflictHandler<Operation>?,
-        dispatchGroup: DispatchGroup?,
         handlerQueue: DispatchQueue,
         resultHandler: OperationResultHandler<Operation>?) {
 
@@ -19,9 +18,7 @@ extension AWSAppSyncClient {
             if success {
                 _ = self.send(
                     operation: operation,
-                    context: nil,
                     conflictResolutionBlock: conflictResolutionBlock,
-                    dispatchGroup: dispatchGroup,
                     handlerQueue: handlerQueue,
                     resultHandler: resultHandler)
             } else {
@@ -33,7 +30,6 @@ extension AWSAppSyncClient {
     func performMutationWithS3Object(
         data: Data,
         s3Object: InternalS3ObjectDetails,
-        dispatchGroup: DispatchGroup?,
         resultHandler: ((JSONObject?, Error?) -> Void)?) {
 
         s3ObjectManager!.upload(s3Object: s3Object) { success, error in

--- a/AWSAppSyncClient/Apollo/Sources/Apollo/Record.swift
+++ b/AWSAppSyncClient/Apollo/Sources/Apollo/Record.swift
@@ -13,7 +13,7 @@ public struct Record {
     self.key = key
     self.fields = fields
   }
-  
+
   public subscript(key: CacheKey) -> Value? {
     get {
       return fields[key]

--- a/AWSAppSyncClient/Internal/AWSAppSyncSubscriptionMetadataCache.swift
+++ b/AWSAppSyncClient/Internal/AWSAppSyncSubscriptionMetadataCache.swift
@@ -15,6 +15,7 @@ final class AWSSubscriptionMetaDataCache {
     private let lastSyncDate = Expression<Date?>("lastSyncDate")
     
     init(fileURL: URL) throws {
+        AppSyncLog.verbose("Initializing subscription metadata cache at \(fileURL.absoluteString)")
         db = try Connection(.uri(fileURL.absoluteString), readonly: false)
         db.busyTimeout = sqlBusyTimeoutConstant
         try createTableIfNeeded()

--- a/AWSAppSyncClient/Internal/AWSOfflineMutation.swift
+++ b/AWSAppSyncClient/Internal/AWSOfflineMutation.swift
@@ -10,7 +10,7 @@ final class AWSAppSyncMutationRecord {
     var jsonRecord: JSONObject?
     var data: Data?
     var contentMap: GraphQLMap?
-    var recordIdentitifer: String
+    var recordIdentifier: String
     var recordState: MutationRecordState = .inQueue
     var timestamp: Date
     var type: MutationType
@@ -21,7 +21,7 @@ final class AWSAppSyncMutationRecord {
         recordIdentifier: String = UUID().uuidString,
         timestamp: Date = Date(),
         type: MutationType = .graphQLMutation) {
-        self.recordIdentitifer = recordIdentifier
+        self.recordIdentifier = recordIdentifier
         self.timestamp = timestamp
         self.type = type
     }
@@ -32,8 +32,8 @@ final class AWSAppSyncMutationRecord {
 extension AWSAppSyncMutationRecord: CustomStringConvertible {
 
     var description: String {
-        var desc: String = "<\(self):\(recordIdentitifer)"
-        desc.append("\tID: \(recordIdentitifer)")
+        var desc: String = "<\(self):\(recordIdentifier)"
+        desc.append("\tID: \(recordIdentifier)")
         desc.append("\ttimestamp: \(timestamp)")
         desc.append("\thasS3Object: \(s3ObjectInput != nil ? true : false)")
         desc.append(">")

--- a/AWSAppSyncClient/Internal/AWSPerformOfflineMutationOperation.swift
+++ b/AWSAppSyncClient/Internal/AWSPerformOfflineMutationOperation.swift
@@ -25,6 +25,10 @@ final class AWSPerformOfflineMutationOperation: AsynchronousOperation, Cancellab
         self.mutation = mutation
     }
 
+    deinit {
+        AppSyncLog.verbose("\(mutation.recordIdentifier): deinit")
+    }
+
     private func send(_ mutation: AWSAppSyncMutationRecord,
                       completion: @escaping ((JSONObject?, Error?) -> Void)) {
         guard
@@ -72,7 +76,7 @@ final class AWSPerformOfflineMutationOperation: AsynchronousOperation, Cancellab
 
             // call master delegate
             offlineMutationDelegate.mutationCallback(
-                recordIdentifier: self.mutation.recordIdentitifer,
+                recordIdentifier: self.mutation.recordIdentifier,
                 operationString: self.mutation.operationString!,
                 snapshot: result,
                 error: error)

--- a/AWSAppSyncClient/Internal/AWSSQLiteNormalizedCache.swift
+++ b/AWSAppSyncClient/Internal/AWSSQLiteNormalizedCache.swift
@@ -31,6 +31,7 @@ final class AWSSQLiteNormalizedCache: NormalizedCache {
     private let record = Expression<String>("record")
 
     init(fileURL: URL) throws {
+        AppSyncLog.verbose("Initializing normalized cache at \(fileURL.absoluteString)")
         db = try Connection(.uri(fileURL.absoluteString), readonly: false)
         db.busyTimeout = sqlBusyTimeoutConstant
         try createTableIfNeeded()
@@ -100,6 +101,7 @@ final class AWSSQLiteNormalizedCache: NormalizedCache {
     }
 
     private func mergeRecords(records: RecordSet) -> Promise<Set<CacheKey>> {
+        AppSyncLog.verbose("Merging \(records.storage.count) records")
 
         return Promise {
             var recordSet = try selectRecords(forKeys: records.keys)

--- a/AWSAppSyncClient/Internal/AppSyncLogHelper.h
+++ b/AWSAppSyncClient/Internal/AppSyncLogHelper.h
@@ -9,10 +9,12 @@
 
 @interface AppSyncLogHelper : NSObject
 
-+(void)logVerbose:(NSString *)message file:(NSString *)file funcion:(NSString *)function line:(NSUInteger)line;
-+(void)logDebug:(NSString *)message file:(NSString *)file funcion:(NSString *)function line:(NSUInteger)line;
-+(void)logInfo:(NSString *)message file:(NSString *)file funcion:(NSString *)function line:(NSUInteger)line;
-+(void)logWarn:(NSString *)message file:(NSString *)file funcion:(NSString *)function line:(NSUInteger)line;
-+(void)logError:(NSString *)message file:(NSString *)file funcion:(NSString *)function line:(NSUInteger)line;
++(BOOL)shouldLogFlag:(AWSDDLogFlag)flag NS_SWIFT_NAME(shouldLog(flag:));
+
++(void)log:(NSString *)message
+      flag:(AWSDDLogFlag)flag
+      file:(NSString *)file
+  function:(NSString *)function
+      line:(NSUInteger)line;
 
 @end

--- a/AWSAppSyncClient/Internal/AppSyncLogHelper.m
+++ b/AWSAppSyncClient/Internal/AppSyncLogHelper.m
@@ -8,69 +8,21 @@
 
 @implementation AppSyncLogHelper
 
-+(void)logVerbose:(NSString *)message file:(NSString *)file funcion:(NSString *)function line:(NSUInteger)line {
-    [AWSDDLog log: YES
-            level: [AWSDDLog sharedInstance].logLevel
-             flag: AWSDDLogFlagVerbose
-          context: 0
-             file: [file cStringUsingEncoding:NSUTF8StringEncoding]
-         function: [function cStringUsingEncoding:NSUTF8StringEncoding]
-             line: line
-              tag: nil
-           format:message
-             args:nil];
++(BOOL)shouldLogFlag:(AWSDDLogFlag)flag {
+    return flag & [AWSDDLog sharedInstance].logLevel;
 }
 
-+(void)logDebug:(NSString *)message file:(NSString *)file funcion:(NSString *)function line:(NSUInteger)line {
++(void)log:(NSString *)message flag:(AWSDDLogFlag)flag file:(NSString *)file function:(NSString *)function line:(NSUInteger)line {
     [AWSDDLog log: YES
             level: [AWSDDLog sharedInstance].logLevel
-             flag: AWSDDLogFlagDebug
+             flag: flag
           context: 0
              file: [file cStringUsingEncoding:NSUTF8StringEncoding]
          function: [function cStringUsingEncoding:NSUTF8StringEncoding]
              line: line
               tag: nil
-           format:message
-             args:nil];
-}
-
-+(void)logInfo:(NSString *)message file:(NSString *)file funcion:(NSString *)function line:(NSUInteger)line {
-    [AWSDDLog log: YES
-            level: [AWSDDLog sharedInstance].logLevel
-             flag: AWSDDLogFlagInfo
-          context: 0
-             file: [file cStringUsingEncoding:NSUTF8StringEncoding]
-         function: [function cStringUsingEncoding:NSUTF8StringEncoding]
-             line: line
-              tag: nil
-           format:message
-             args:nil];
-}
-
-+(void)logWarn:(NSString *)message file:(NSString *)file funcion:(NSString *)function line:(NSUInteger)line {
-    [AWSDDLog log: YES
-            level: [AWSDDLog sharedInstance].logLevel
-             flag: AWSDDLogFlagWarning
-          context: 0
-             file: [file cStringUsingEncoding:NSUTF8StringEncoding]
-         function: [function cStringUsingEncoding:NSUTF8StringEncoding]
-             line: line
-              tag: nil
-           format:message
-             args:nil];
-}
-
-+(void)logError:(NSString *)message file:(NSString *)file funcion:(NSString *)function line:(NSUInteger)line {
-    [AWSDDLog log: YES
-            level: [AWSDDLog sharedInstance].logLevel
-             flag: AWSDDLogFlagError
-          context: 0
-             file: [file cStringUsingEncoding:NSUTF8StringEncoding]
-         function: [function cStringUsingEncoding:NSUTF8StringEncoding]
-             line: line
-              tag: nil
-           format:message
-             args:nil];
+           format: message
+             args: nil];
 }
 
 @end

--- a/AWSAppSyncClient/Internal/AppSyncLogWrapper.swift
+++ b/AWSAppSyncClient/Internal/AppSyncLogWrapper.swift
@@ -5,23 +5,34 @@
 //
 
 final class AppSyncLog {
-    class func verbose(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        AppSyncLogHelper.logVerbose(message, file: file, funcion: function, line: UInt(line))
+    class func verbose(_ message: @autoclosure () -> String, file: String = #file, function: String = #function, line: Int = #line) {
+        log(message, flag: .verbose, file: file, function: function, line: line)
     }
     
-    class func debug(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        AppSyncLogHelper.logVerbose(message, file: file, funcion: function, line: UInt(line))
+    class func debug(_ message: @autoclosure () -> String, file: String = #file, function: String = #function, line: Int = #line) {
+        log(message, flag: .debug, file: file, function: function, line: line)
     }
     
-    class func info(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        AppSyncLogHelper.logVerbose(message, file: file, funcion: function, line: UInt(line))
+    class func info(_ message: @autoclosure () -> String, file: String = #file, function: String = #function, line: Int = #line) {
+        log(message, flag: .info, file: file, function: function, line: line)
     }
     
-    class func warn(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        AppSyncLogHelper.logVerbose(message, file: file, funcion: function, line: UInt(line))
+    class func warn(_ message: @autoclosure () -> String, file: String = #file, function: String = #function, line: Int = #line) {
+        log(message, flag: .warning, file: file, function: function, line: line)
     }
     
-    class func error(_ message: String, file: String = #file, function: String = #function, line: Int = #line) {
-        AppSyncLogHelper.logVerbose(message, file: file, funcion: function, line: UInt(line))
+    class func error(_ message: @autoclosure () -> String, file: String = #file, function: String = #function, line: Int = #line) {
+        log(message, flag: .error, file: file, function: function, line: line)
     }
+
+    private class func log(_ message: @autoclosure () -> String, flag: AWSDDLogFlag, file: String, function: String, line: Int) {
+        if AppSyncLogHelper.shouldLog(flag: flag) {
+            AppSyncLogHelper.log(message(),
+                                 flag: flag,
+                                 file: file,
+                                 function: function,
+                                 line: UInt(line))
+        }
+    }
+
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The AWS AppSync SDK for iOS enables you to access your AWS AppSync backend and p
 
 ### Bug fixes
 
+- Fixed incorrect AWSCore dependency version in podspec ([Issue #190](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/190))
+
+### Misc. Updates
+
+- Added `AWSAppSyncClientLogFormatter` utility class. Developers who want to use it can add it to the appropriate logger. For example, a configuration like:
+    ```swift
+    AWSDDLog.sharedInstance.logLevel = .verbose
+    AWSDDTTYLogger.sharedInstance.logFormatter = AWSAppSyncClientLogFormatter()
+    AWSDDLog.sharedInstance.add(AWSDDTTYLogger.sharedInstance)
+    ```
+  would output log messages like:
+    ```
+    2019-03-04 07:21:32.131-0800 [I AWSAppSyncClient.init(appSyncConfig:reachabilityFactory:), L75] Initializing AppSyncClient
+    2019-03-04 07:21:32.135-0800 [V AWSPerformMutationQueue.init(appSyncClient:networkClient:reachabiltyChangeNotifier:cacheFileURL:), L24] Initializing AWSPerformMutationQueue
+    2019-03-04 07:21:32.135-0800 [V AWSPerformMutationQueue.resume(), L95] Resuming OperationQueue
+    ```
+- Added some verbose logging around mutation queue handling; minor log additions elsewhere
+- Minor dead code removal & miscellaneous cleanup
+
+## 2.10.2
+
+### Bug fixes
+
 - Fixed a bug where queries with dots (`"."`) in the arguments were not being properly cached ([Issue #110](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/110), [#165](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/165))
 - `AWSAppSyncClient.perform(mutation:queue:optimisticUpdate:conflictResolutionBlock:resultHandler:)` now properly invokes its result handler callbacks on the supplied `queue` instead of always using `DispatchQueue.main`
 


### PR DESCRIPTION
- Added logging helpers, added logging around mutation queue actions
- AppSyncLog's `message` argument is now an autoclosure
- Removed unused DispatchGroup from send operation
- Removed unused context arg to send

*Issue #, if available:*
Fixes pending release: #190

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
