### PR TITLE
delete an  offline mutation from cache when it's canceled

### DIFF
--- a/AWSAppSyncClient/Internal/AWSPerformMutationOperation.swift
+++ b/AWSAppSyncClient/Internal/AWSPerformMutationOperation.swift
@@ -103,6 +103,7 @@ final class AWSPerformMutationOperation<Mutation: GraphQLMutation>: Asynchronous
     override func cancel() {
         super.cancel()
         networkTask?.cancel()
+        self.notifyCompletion(nil, error: nil)
     }
 
     // MARK: - CustomStringConvertible

--- a/AWSAppSyncUnitTests/MutationQueueTests.swift
+++ b/AWSAppSyncUnitTests/MutationQueueTests.swift
@@ -616,7 +616,31 @@ class MutationQueueTests: XCTestCase {
 
         wait(for: [mutationWasPerformed], timeout: 1.0)
     }
-
+    
+    func testCancelingOfflineMutationRemovesFromQueue() throws {
+        
+        let reachability = MockReachabilityProvidingFactory.instance
+        try reachability.startNotifier()
+        reachability.connection = .none
+        
+        NetworkReachabilityNotifier.setupShared(
+            host: "http://www.amazon.com",
+            allowsCellularAccess: true,
+            reachabilityFactory: MockReachabilityProvidingFactory.self)
+        
+        let addPost = DefaultTestPostData.defaultCreatePostWithoutFileUsingParametersMutation
+        let mockHTTPTransport = MockAWSNetworkTransport()
+        
+        let persistentCache = try AWSMutationCache(fileURL: cacheConfiguration.offlineMutations!)
+        let n0 = try persistentCache.getStoredMutationRecordsInQueue().await().count
+        let appSyncClient = try UnitTestHelpers.makeAppSyncClient(using: mockHTTPTransport, cacheConfiguration: cacheConfiguration)
+        let cancellable = appSyncClient.perform(mutation: addPost) { _, _ in }
+        let n1 = try persistentCache.getStoredMutationRecordsInQueue().await().count
+        XCTAssertEqual(n0, n1 - 1 )
+        cancellable.cancel()
+        let n2 = try persistentCache.getStoredMutationRecordsInQueue().await().count
+        XCTAssertEqual(n0, n2)
+    }
     // MARK: - Utility methods
 
     func makeTestMutationWithoutParametersResponseBody(withValue value: Bool) -> JSONObject {
@@ -624,3 +648,4 @@ class MutationQueueTests: XCTestCase {
     }
 
 }
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The AWS AppSync SDK for iOS enables you to access your AWS AppSync backend and p
 
 - Fixed incorrect AWSCore dependency version in podspec ([Issue #190](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/190))
 - Fixed data races in AppSyncMQTTClient that were causing crashes ([Issue #184](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/184))
+- Fixed bug where canceling a mutation properly removes it from the persistent mutation cache.  ([Issue #187](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/187))
 
 ### Misc. Updates
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix a bug in AWSPerformMutationOperation.cancle, so that a mutation can be deleted from the persistent database when it's canceled ([Issue #187](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/187))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
