### PR TITLE
Fix issue #187. Remove mutation from persistent store when cancelled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ also includes support for offline operations.
 
 ### Bug Fixes
 - Updated SQLite.swift to master to fix caching error. ([Issue #211](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/211))
+- Fixed a bug where cancelled mutations would not be cleared from the persistent store and would be sent to service on app restart. See [issue #187](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/187)
 
 ### Misc. Updates
 - Updated AWS SDK dependencies to 2.9.5


### PR DESCRIPTION
*Issue #, if available:*
#187 

*Description of changes:*
- The `cancel` logic was missing a callback to the `operationCompletionHandler` which is responsible for deleting the mutation from the queue. Added a callback and ensured developer callback is not invoked in that case.

Integration and unit tests pass locally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
