### PR TITLE
Improvements for subscription cancelleation and disconnects.

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -2655,6 +2655,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.palpatim.AWSAppSyncIntegrationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAppSyncTestHostApp.app/AWSAppSyncTestHostApp";
@@ -2679,6 +2680,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.palpatim.AWSAppSyncIntegrationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AWSAppSyncTestHostApp.app/AWSAppSyncTestHostApp";

--- a/AWSAppSyncClient/MQTTSDK/AWSIoTMQTTClient.m
+++ b/AWSAppSyncClient/MQTTSDK/AWSIoTMQTTClient.m
@@ -957,6 +957,10 @@ static const NSString *SDK_VERSION = @"2.6.19";
                                                                      object:nil];
                     self.reconnectThread.name = [NSString stringWithFormat:@"AWSIoTMQTTClient reconnect %@", self.clientId];
                     [self.reconnectThread start];
+                } else {
+                    //Clear all session state here as once disconnected, we do not retain any metadata.
+                    // This is done currently on `self.userDidIssueDisconnect`, but not when the error is from MQTT session error.
+                    [self.topicListeners removeAllObjects];
                 }
             }
             break;
@@ -986,6 +990,10 @@ static const NSString *SDK_VERSION = @"2.6.19";
                     self.reconnectThread = [[NSThread alloc] initWithTarget:self selector:@selector(initiateReconnectTimer:) object:nil];
                     self.reconnectThread.name = [NSString stringWithFormat:@"AWSIoTMQTTClient reconnect %@", self.clientId];
                     [self.reconnectThread start];
+                } else {
+                    // Clear all session state here as once errored out, we do not retain any metadata.
+                    // This is done currently on `self.userDidIssueDisconnect`, but not when the error is from MQTT session error.
+                    [self.topicListeners removeAllObjects];
                 }
             }
             break;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ also includes support for offline operations.
 
 * Make network reachability provider mockable See [PR #245](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/pull/245). Thanks @gleue! 🎉
 
+### Bug Fixes
+
+* Improved internal handling of subscription cancellation and disconnect.
+  - With this update, the cancellation behavior for subscription is more robust in both cases - when developer issues `cancel` and when SDK notifies `connectionError` in the `statusChangeHandler` and `resultHandler`
+  - As a best practice, we recommend that if you do not want to receive any more callbacks on the `statusChangeHandler` and `resultHandler` for the subscription, issue a `cancel` which would immediately stop all communication to the watcher.
+  - Once `cancel` is issued, no notifications or error callbacks will be given to the watcher. If the watcher object is not reference from application code, it will internally issue a `cancel` and ensure that no callbacks are given. 
+
 ## 2.12.0
 
 ### Bug Fixes


### PR DESCRIPTION
*Description of changes:*

- Better handling of user initiated `cancel`
- Better handling of MQTT issued error
- Previously if the `SubscriptionWatcher` received an error status, it was responsible to invoke clean up for `AppSyncMQTTClient` by calling `cancel`
-  New behavior does automatic clean up in `AppSyncMQTTClient` if a connection error is encountered
- New tests to verify separation of concern and above mentioned behavior


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
