### PR TITLE
Fix a bug which blocks subscription from starting after being cancelled.

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		17E009DA1FCAB234005031DB /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E009B81FCAB233005031DB /* Result.swift */; };
 		17E009DB1FCAB234005031DB /* NormalizedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E009B91FCAB234005031DB /* NormalizedCache.swift */; };
 		17E009DC1FCAB234005031DB /* ApolloClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E009BA1FCAB234005031DB /* ApolloClient.swift */; };
+		17E4F27D2282835A00E92474 /* SubscriptionCancelAndRestartTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E4F27C2282835A00E92474 /* SubscriptionCancelAndRestartTests.swift */; };
 		17FD3F58225BAE9A00BD12F8 /* AWSAppSyncRetryStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FD3F57225BAE9A00BD12F8 /* AWSAppSyncRetryStrategy.swift */; };
 		3D9BF115227836800079F52F /* NetworkReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9BF114227836800079F52F /* NetworkReachability.swift */; };
 		70C68E4D132FE62623DB8C07 /* Pods_AWSAppSyncTestHostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C707001F57B091A8A001CAB /* Pods_AWSAppSyncTestHostApp.framework */; };
@@ -503,6 +504,7 @@
 		17E009B81FCAB233005031DB /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Result.swift; path = Apollo/Sources/Apollo/Result.swift; sourceTree = "<group>"; };
 		17E009B91FCAB234005031DB /* NormalizedCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NormalizedCache.swift; path = Apollo/Sources/Apollo/NormalizedCache.swift; sourceTree = "<group>"; };
 		17E009BA1FCAB234005031DB /* ApolloClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ApolloClient.swift; path = Apollo/Sources/Apollo/ApolloClient.swift; sourceTree = "<group>"; };
+		17E4F27C2282835A00E92474 /* SubscriptionCancelAndRestartTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionCancelAndRestartTests.swift; sourceTree = "<group>"; };
 		17FD3F57225BAE9A00BD12F8 /* AWSAppSyncRetryStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAppSyncRetryStrategy.swift; sourceTree = "<group>"; };
 		1CC71FAD4E9B09922B42E040 /* Pods_AWSAppSync_AWSAppSyncIntegrationTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSAppSync_AWSAppSyncIntegrationTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CDE7D0207B12E4A01B1241D /* Pods-AWSAppSyncTestHostApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSyncTestHostApp.release.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSyncTestHostApp/Pods-AWSAppSyncTestHostApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -1043,6 +1045,7 @@
 				FA88834621E3D05800DEBCB3 /* ReachabilityChangeNotifierTests.swift */,
 				FAD17C7021C2ABEA008D116C /* SubscriptionMessagesQueueTests.swift */,
 				FAD17C6821C16E58008D116C /* SyncStrategyTests.swift */,
+				17E4F27C2282835A00E92474 /* SubscriptionCancelAndRestartTests.swift */,
 			);
 			path = AWSAppSyncUnitTests;
 			sourceTree = "<group>";
@@ -2005,6 +2008,7 @@
 				FABD70752205101600C99B47 /* AWSAppSyncClientInfoTests.swift in Sources */,
 				FA00595A221222D800BFBD13 /* MutationOptimisticUpdateTests.swift in Sources */,
 				FA1A620C21E6533A00AA54D0 /* AWSAppSyncRetryHandlerTests.swift in Sources */,
+				17E4F27D2282835A00E92474 /* SubscriptionCancelAndRestartTests.swift in Sources */,
 				FA38636E21DD8FF200DBA2BC /* MutationQueueTests.swift in Sources */,
 				FA4F0D9821D6EDA50099D165 /* SyncStrategyTests.swift in Sources */,
 				FA4F0D9721D6EDA20099D165 /* AWSAppSyncServiceConfigTests.swift in Sources */,

--- a/AWSAppSyncClient/AWSAppSyncSubscriptionWatcher.swift
+++ b/AWSAppSyncClient/AWSAppSyncSubscriptionWatcher.swift
@@ -225,7 +225,7 @@ public final class AWSAppSyncSubscriptionWatcher<Subscription: GraphQLSubscripti
         // We signal the semaphore here to ensure that if the subscription request is waiting for HTTP call to return,
         // we do not block on it. The subscription is already cancelled and we can release the wait for other
         // subscriptions to resume.
-        self.semaphore.signal()
+        semaphore.signal()
         httpClient = nil
         resultHandler = nil
         statusChangeHandler = nil

--- a/AWSAppSyncUnitTests/SubscriptionCancelAndRestartTests.swift
+++ b/AWSAppSyncUnitTests/SubscriptionCancelAndRestartTests.swift
@@ -1,0 +1,83 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Amazon Software License
+// http://aws.amazon.com/asl/
+//
+
+import Foundation
+import XCTest
+@testable import AWSAppSync
+@testable import AWSCore
+@testable import AWSAppSyncTestCommon
+
+class SubscriptionCancelAndRestartTests: XCTestCase {
+    
+    func testStartStopStartSubscriptions() {
+        let secondsToWait = 1
+        let subscriptionWatchers = 5
+        
+        // To test this case, we'll set up a mock http transport which has a delay before responding back to the caller
+        // This ensures that the subscription watchers can call `cancel` before the response comes back and thus allowing
+        // to mimick cases where calling cancel / start rapidly for subscriptions does not cause issues.
+        let mockHTTPTransport = MockAWSNetworkTransport()
+        
+        // First add a response block that delays response to subscription request
+        let delayedResponseBlock: SendOperationResponseBlock<OnUpvotePostSubscription> = {
+            operation, completionHandler in
+            DispatchQueue.global().asyncAfter(deadline: DispatchTime.now() + .seconds(secondsToWait)) {
+                completionHandler(nil, AWSAppSyncSubscriptionError.connectionError)
+            }
+        }
+        
+        // Create client without any persistent cache but using our mock http transport
+        let appSyncClient: AWSAppSyncClient = try! UnitTestHelpers.makeAppSyncClient(using: mockHTTPTransport, cacheConfiguration: nil)
+        
+        let watchersWhichShouldReceiveCallbackExpectation = expectation(description: "HTTP block of subscription was received.")
+        watchersWhichShouldReceiveCallbackExpectation.expectedFulfillmentCount  =  subscriptionWatchers
+        
+        let watchersWhichShouldNotReceiveCallbackExpectation = expectation(description: "HTTP block of subscription should not be received.")
+        watchersWhichShouldNotReceiveCallbackExpectation.isInverted = true
+        
+        // we create a dictionary where we hold all the watchers; this mimicks app holding reference to watchers
+        var watchers: [String: AWSAppSyncSubscriptionWatcher<OnUpvotePostSubscription>] = [:]
+        
+        // create an array of object ids to be used in subscription
+        var subscriptionIds: [String] = []
+        for _ in 0 ..< subscriptionWatchers  {
+            subscriptionIds.append(UUID().uuidString)
+        }
+        
+        // Initiate subscription requests for the generated object ids
+        for uuid in subscriptionIds {
+            mockHTTPTransport.sendOperationResponseQueue.append(delayedResponseBlock)
+            let watcher = try! appSyncClient.subscribe(subscription: OnUpvotePostSubscription(id: uuid)) { (_, _, error) in
+                if error != nil {
+                    // No callbacks are expected here since the subscriptions are cancelled immediately
+                    watchersWhichShouldNotReceiveCallbackExpectation.fulfill()
+                }
+            }
+            watchers[uuid] = watcher
+        }
+        // Immediately cancel all subscriptions (before delayed http callback which we implemented above can be executed.)
+        for uuid in subscriptionIds {
+            watchers[uuid]?.cancel()
+        }
+        // Remove references
+        watchers.removeAll()
+        
+        // Try starting the subscriptions again
+        for uuid in subscriptionIds {
+            mockHTTPTransport.sendOperationResponseQueue.append(delayedResponseBlock)
+            let watcher = try! appSyncClient.subscribe(subscription: OnUpvotePostSubscription(id: uuid)) { (_, _, error) in
+                // All 5 subscriptions should receive callbacks. They should not be stuck in a frozen state.
+                if error != nil {
+                    watchersWhichShouldReceiveCallbackExpectation.fulfill()
+                }
+            }
+            watchers[uuid] = watcher
+        }
+        
+        // Wait to ensure that correct callbacks are made and no subscription requests are frozen.
+        wait(for: [watchersWhichShouldReceiveCallbackExpectation, watchersWhichShouldNotReceiveCallbackExpectation], timeout: Double(subscriptionWatchers) * Double(secondsToWait) + 1.0)
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The AWS AppSync SDK for iOS enables you to access your AWS AppSync backend and perform operations like `Queries`, `Mutations` and `Subscriptions`. The SDK
 also includes support for offline operations.
 
+
+## 2.12.2
+
+### Bug Fixes
+
+* Fix a bug where subscriptions would be blocked from starting again after being cancelled. See [issue #249](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/249)
+
 ## 2.12.1
 
 ### Misc. Updates


### PR DESCRIPTION
*Issue #, if available:*
#249 

*Description of changes:*
- Signal the semaphore from `cancel` method since we do not want to block any other subscriptions
- Added unit test which validates the behavior
- Added functional test which validates the behavior with actual subscription requests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
