### PR TITLE
Skipping integ tests by default b/c of TravisCI instability

### DIFF
--- a/AWSAppSyncClient.xcodeproj/xcshareddata/xcschemes/AWSAppSync.xcscheme
+++ b/AWSAppSyncClient.xcodeproj/xcshareddata/xcschemes/AWSAppSync.xcscheme
@@ -50,7 +50,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "FA8C62BF21D6E41600FF9924"

--- a/AWSAppSyncClient/Internal/AppSyncMQTTClient.swift
+++ b/AWSAppSyncClient/Internal/AppSyncMQTTClient.swift
@@ -224,7 +224,6 @@ class AppSyncMQTTClient: AWSIoTMQTTClientDelegate {
         }
     }
     
-    
     /// Cleans up internal book keeping where we hold the topic-client mapping.
     /// This method must be called from `concurrencyQueue`.
     ///


### PR DESCRIPTION
Tests pass locally.

From this change, the team will be responsible for running the integration tests locally, using the us-east-2 credentials, prior to a release.