### PR TITLE
use minimum of the number of bytes or 128

### DIFF
--- a/AWSAppSyncClient/AWSAppSyncSubscriptionWatcher.swift
+++ b/AWSAppSyncClient/AWSAppSyncSubscriptionWatcher.swift
@@ -255,7 +255,7 @@ public final class AWSAppSyncSubscriptionWatcher<Subscription: GraphQLSubscripti
     func messageCallbackDelegate(data: Data) {
         do {
             AppSyncLog.debug("Received message")
-            AppSyncLog.verbose("First 128 bytes of message data is [\(data.prefix(upTo: 128))]")
+            AppSyncLog.verbose("First \(min(data.count, 128)) bytes of message data is [\(data.prefix(upTo: min(data.count, 128)))]")
 
             guard String(data: data, encoding: .utf8) != nil else {
                 let error = AWSAppSyncSubscriptionError.messageCallbackError("Unable to convert message data to String using UTF8 encoding")


### PR DESCRIPTION
*Issue #, if available:* #258, #216 

*Description of changes:* Refactored the verbose logging message in the subscription watcher so that it will output the minimum between `data.count` and `128` bytes. This should prevent any out of bounds exception that could be caused by `Data.prefix(upTo:...)`

If this isn't the desired fix, please provide any direction and I can adjust as needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
