### PR TITLE
Fix delta sync bug

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		70C68E4D132FE62623DB8C07 /* Pods_AWSAppSyncTestHostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C707001F57B091A8A001CAB /* Pods_AWSAppSyncTestHostApp.framework */; };
 		8032C5415EF414C038394D69 /* Pods_AWSAppSyncTestCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 74071C397A83DEA980BB2F4C /* Pods_AWSAppSyncTestCommon.framework */; };
 		A70604C0C722923A70C937A1 /* Pods_AWSAppSyncTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57F5A94352E1ABE35159489D /* Pods_AWSAppSyncTestApp.framework */; };
+		B48056BC22A992E200E4F742 /* AppSyncSubscriptionWithSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B48056BB22A992E200E4F742 /* AppSyncSubscriptionWithSyncTests.swift */; };
 		C4980354FE541C9D8DC01364 /* Pods_ApolloTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CF13D1596371E9B5875900A8 /* Pods_ApolloTests.framework */; };
 		CC96F8A521BABE5600446EBD /* AWSPerformMutationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC96F8A421BABE5600446EBD /* AWSPerformMutationQueue.swift */; };
 		CC96F8A721BACA1C00446EBD /* SessionMutationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC96F8A621BACA1C00446EBD /* SessionMutationOperation.swift */; };
@@ -532,6 +533,7 @@
 		AC900D19F2ADD7D9AA202420 /* Pods-AWSAppSyncTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSyncTestApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSyncTestApp/Pods-AWSAppSyncTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		AD111EB21748A599F5796B74 /* Pods-AWSAppSync.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSync.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSync/Pods-AWSAppSync.debug.xcconfig"; sourceTree = "<group>"; };
 		AE7015F188184AE5B561E7F0 /* Pods_AWSAppSync_AWSAppSyncUnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AWSAppSync_AWSAppSyncUnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B48056BB22A992E200E4F742 /* AppSyncSubscriptionWithSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncSubscriptionWithSyncTests.swift; sourceTree = "<group>"; };
 		C38567A6FD373D3EE5D7EBC1 /* Pods-AWSAppSync-AWSAppSyncIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSync-AWSAppSyncIntegrationTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSync-AWSAppSyncIntegrationTests/Pods-AWSAppSync-AWSAppSyncIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		C6767DE816922ABC0E53CF4C /* Pods-AWSAppSyncTestCommon.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSyncTestCommon.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSyncTestCommon/Pods-AWSAppSyncTestCommon.debug.xcconfig"; sourceTree = "<group>"; };
 		C830ED8003E746C4C6799F8E /* Pods-AWSAppSync.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSync.release.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSync/Pods-AWSAppSync.release.xcconfig"; sourceTree = "<group>"; };
@@ -1051,6 +1053,7 @@
 				FAD17C6821C16E58008D116C /* SyncStrategyTests.swift */,
 				17E4F27C2282835A00E92474 /* SubscriptionMiscTests.swift */,
 				E47789582284B3DC008E7D6E /* MockAWSAppSyncServiceConfig.swift */,
+				B48056BB22A992E200E4F742 /* AppSyncSubscriptionWithSyncTests.swift */,
 			);
 			path = AWSAppSyncUnitTests;
 			sourceTree = "<group>";
@@ -2018,6 +2021,7 @@
 				FA38636E21DD8FF200DBA2BC /* MutationQueueTests.swift in Sources */,
 				FA4F0D9821D6EDA50099D165 /* SyncStrategyTests.swift in Sources */,
 				FA4F0D9721D6EDA20099D165 /* AWSAppSyncServiceConfigTests.swift in Sources */,
+				B48056BC22A992E200E4F742 /* AppSyncSubscriptionWithSyncTests.swift in Sources */,
 				FAC28D3B221B0F09000F84CD /* CacheKeyTests.swift in Sources */,
 				E47789592284B3DC008E7D6E /* MockAWSAppSyncServiceConfig.swift in Sources */,
 				FA4F0D9521D6ED9E0099D165 /* AppSyncClientComplexObjectMutationUnitTests.swift in Sources */,

--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -1035,6 +1035,7 @@
 			children = (
 				CCEF79DA21DE7CA6004AD64D /* AppSyncApolloCustomizationTests.swift */,
 				FAEC08E021CBE8B900A816DE /* AppSyncClientComplexObjectMutationUnitTests.swift */,
+				B48056BB22A992E200E4F742 /* AppSyncSubscriptionWithSyncTests.swift */,
 				FAC3E711220900A20037813E /* AWSAppSyncCacheConfigurationMigrationTests.swift */,
 				FAFB258822051D9600068B38 /* AWSAppSyncCacheConfigurationTests.swift */,
 				FA0C12C721CD96BF00B438CB /* AWSAppSyncClientConfigurationTests.swift */,
@@ -1046,14 +1047,13 @@
 				FAC28D3A221B0F09000F84CD /* CacheKeyTests.swift */,
 				FAE1E0EE21D3DC9A005767C7 /* Foundation+UtilsTests.swift */,
 				FA8C62B521D6E3AA00FF9924 /* Info.plist */,
+				E47789582284B3DC008E7D6E /* MockAWSAppSyncServiceConfig.swift */,
 				FA005959221222D800BFBD13 /* MutationOptimisticUpdateTests.swift */,
 				FA38636D21DD8FF200DBA2BC /* MutationQueueTests.swift */,
 				FA88834621E3D05800DEBCB3 /* ReachabilityChangeNotifierTests.swift */,
 				FAD17C7021C2ABEA008D116C /* SubscriptionMessagesQueueTests.swift */,
-				FAD17C6821C16E58008D116C /* SyncStrategyTests.swift */,
 				17E4F27C2282835A00E92474 /* SubscriptionMiscTests.swift */,
-				E47789582284B3DC008E7D6E /* MockAWSAppSyncServiceConfig.swift */,
-				B48056BB22A992E200E4F742 /* AppSyncSubscriptionWithSyncTests.swift */,
+				FAD17C6821C16E58008D116C /* SyncStrategyTests.swift */,
 			);
 			path = AWSAppSyncUnitTests;
 			sourceTree = "<group>";

--- a/AWSAppSyncClient/Internal/AppSyncSubscriptionWithSync.swift
+++ b/AWSAppSyncClient/Internal/AppSyncSubscriptionWithSync.swift
@@ -490,22 +490,22 @@ final class AppSyncSubscriptionWithSync<Subscription: GraphQLSubscription, BaseQ
     /// supplied GraphQL operations. The hash is always same for the same set of operations.
     /// - Returns: The unique hash for the specified queries & subscription.
     internal func getOperationHash() -> String {
-        
+
         var baseString = ""
-        
+
         let variables = baseQuery.variables?.sorted(by: { $0.0 < $1.0 }).description ?? ""
         baseString += type(of: baseQuery).requestString + variables
-        
+
         if let subscription = subscription {
-            let variables = subscription.variables?.sorted(by: { $0.0 < $1.0 }).description  ?? ""
+            let variables = subscription.variables?.sorted(by: { $0.0 < $1.0 }).description ?? ""
             baseString += type(of: subscription).requestString + variables
         }
-        
+
         if let deltaQuery = deltaQuery {
             let variables = deltaQuery.variables?.sorted(by: { $0.0 < $1.0 }).description ?? ""
             baseString += type(of: deltaQuery).requestString + variables
         }
-        
+
         return AWSSignatureSignerUtility.hash(baseString.data(using: .utf8)!)!.base64EncodedString()
     }
     

--- a/AWSAppSyncClient/Internal/AppSyncSubscriptionWithSync.swift
+++ b/AWSAppSyncClient/Internal/AppSyncSubscriptionWithSync.swift
@@ -489,21 +489,21 @@ final class AppSyncSubscriptionWithSync<Subscription: GraphQLSubscription, BaseQ
     /// This function generates a unique identifier hash for the combination of specified parameters in the
     /// supplied GraphQL operations. The hash is always same for the same set of operations.
     /// - Returns: The unique hash for the specified queries & subscription.
-    private func getOperationHash() -> String {
+    internal func getOperationHash() -> String {
         
         var baseString = ""
         
-        let variables = baseQuery.variables?.description ?? ""
-        baseString = type(of: baseQuery).requestString + variables
-
+        let variables = baseQuery.variables?.sorted(by: { $0.0 < $1.0 }).description ?? ""
+        baseString += type(of: baseQuery).requestString + variables
+        
         if let subscription = subscription {
-            let variables = subscription.variables?.description ?? ""
-            baseString = type(of: subscription).requestString + variables
+            let variables = subscription.variables?.sorted(by: { $0.0 < $1.0 }).description  ?? ""
+            baseString += type(of: subscription).requestString + variables
         }
         
         if let deltaQuery = deltaQuery {
-            let variables = deltaQuery.variables?.description ?? ""
-            baseString = type(of: deltaQuery).requestString + variables
+            let variables = deltaQuery.variables?.sorted(by: { $0.0 < $1.0 }).description ?? ""
+            baseString += type(of: deltaQuery).requestString + variables
         }
         
         return AWSSignatureSignerUtility.hash(baseString.data(using: .utf8)!)!.base64EncodedString()

--- a/AWSAppSyncUnitTests/AppSyncSubscriptionWithSyncTests.swift
+++ b/AWSAppSyncUnitTests/AppSyncSubscriptionWithSyncTests.swift
@@ -10,24 +10,24 @@ import XCTest
 
 class AppSyncSubscriptionWithSyncTests: XCTestCase {
     
-    var appsyncClient: AWSAppSyncClient?
-    let queue = DispatchQueue.main
+    var appsyncClient: AWSAppSyncClient!
+    let queue = DispatchQueue(label: "com.amazon.aws.test")
     let syncConfiguration = SyncConfiguration(baseRefreshIntervalInSeconds: 2)
     
     let emptyQuery = AWSAppSyncClient.EmptyQuery()
-    let emptyQueryHandler : OperationResultHandler<AWSAppSyncClient.EmptyQuery> = {(_, _) in}
+    let emptyQueryHandler: OperationResultHandler<AWSAppSyncClient.EmptyQuery> = {(_, _) in}
     
     let listPostsQuery = ListPostsQuery()
-    let listQueryHandler : OperationResultHandler<ListPostsQuery> = {(_, _) in}
+    let listQueryHandler: OperationResultHandler<ListPostsQuery> = {(_, _) in}
     
     private let getQuery = GraphGetQuery(id: "2")
-    private let getQueryHandler : OperationResultHandler<GraphGetQuery> = {(_, _) in}
+    private let getQueryHandler: OperationResultHandler<GraphGetQuery> = {(_, _) in}
     
-    let deltaQueryHandler : DeltaQueryResultHandler<ListPostsQuery> = {(_, _, _) in}
-    let emptyDeltaQueryHandler : DeltaQueryResultHandler<AWSAppSyncClient.EmptyQuery> = {(_, _, _) in}
+    let deltaQueryHandler: DeltaQueryResultHandler<ListPostsQuery> = {(_, _, _) in}
+    let emptyDeltaQueryHandler: DeltaQueryResultHandler<AWSAppSyncClient.EmptyQuery> = {(_, _, _) in}
     
     let subscription = OnUpvotePostSubscription(id: UUID().uuidString)
-    let subscriptionResultHandler : SubscriptionResultHandler<OnUpvotePostSubscription> = { (_, _, _) in }
+    let subscriptionResultHandler: SubscriptionResultHandler<OnUpvotePostSubscription> = { (_, _, _) in }
     
     let emptySubscription = AWSAppSyncClient.EmptySubscription.init()
     let emptySubscriptionResultHandler: SubscriptionResultHandler<AWSAppSyncClient.EmptySubscription> = { (_, _, _) in }
@@ -35,59 +35,69 @@ class AppSyncSubscriptionWithSyncTests: XCTestCase {
     override func setUp() {
         do {
             let mockHTTPTransport = MockAWSNetworkTransport()
-            appsyncClient = try UnitTestHelpers.makeAppSyncClient(using: mockHTTPTransport, cacheConfiguration: AWSAppSyncCacheConfiguration())
+            appsyncClient = try UnitTestHelpers.makeAppSyncClient(
+                using: mockHTTPTransport,
+                cacheConfiguration: AWSAppSyncCacheConfiguration())
         } catch {
             XCTFail("Error thrown during initialization: \(error)")
         }
     }
     
     func testWithAllValuesFilled() {
-        let subscriptionWithSync = AppSyncSubscriptionWithSync<OnUpvotePostSubscription, ListPostsQuery, ListPostsQuery>(appSyncClient: appsyncClient!,
-                                                                                                                         baseQuery: listPostsQuery,
-                                                                                                                         deltaQuery: listPostsQuery,
-                                                                                                                         subscription: subscription,
-                                                                                                                         baseQueryHandler: listQueryHandler,
-                                                                                                                         deltaQueryHandler: deltaQueryHandler,
-                                                                                                                         subscriptionResultHandler: subscriptionResultHandler,
-                                                                                                                         subscriptionMetadataCache: nil,
-                                                                                                                         syncConfiguration: syncConfiguration,
-                                                                                                                         handlerQueue: queue)
+        
+        let subscriptionWithSync = AppSyncSubscriptionWithSync(
+            appSyncClient: appsyncClient,
+            baseQuery: listPostsQuery,
+            deltaQuery: listPostsQuery,
+            subscription: subscription,
+            baseQueryHandler: listQueryHandler,
+            deltaQueryHandler: deltaQueryHandler,
+            subscriptionResultHandler: subscriptionResultHandler,
+            subscriptionMetadataCache: nil,
+            syncConfiguration: syncConfiguration,
+            handlerQueue: queue)
         let result = subscriptionWithSync.getOperationHash()
         XCTAssertNotNil(result, "Should produce a non nil hash when all fields are present.")
     }
     
     func testWithOneEmptyValue() {
         
-        let syncWithEmptyBaseQuery = AppSyncSubscriptionWithSync<OnUpvotePostSubscription, AWSAppSyncClient.EmptyQuery, ListPostsQuery>(appSyncClient: appsyncClient!,
-                                                                                                                                        baseQuery: emptyQuery,
-                                                                                                                                        deltaQuery: listPostsQuery,
-                                                                                                                                        subscription: subscription,
-                                                                                                                                        baseQueryHandler: emptyQueryHandler,
-                                                                                                                                        deltaQueryHandler: deltaQueryHandler,
-                                                                                                                                        subscriptionResultHandler: subscriptionResultHandler,
-                                                                                                                                        subscriptionMetadataCache: nil,
-                                                                                                                                        syncConfiguration: syncConfiguration,
-                                                                                                                                        handlerQueue: queue)
-        let syncWithEmptyDeltaQuery = AppSyncSubscriptionWithSync<OnUpvotePostSubscription, ListPostsQuery, AWSAppSyncClient.EmptyQuery>(appSyncClient: appsyncClient!,
-                                                                                                                                         baseQuery: listPostsQuery,
-                                                                                                                                         deltaQuery: emptyQuery,
-                                                                                                                                         subscription: subscription,
-                                                                                                                                         baseQueryHandler: listQueryHandler,
-                                                                                                                                         deltaQueryHandler: emptyDeltaQueryHandler,
-                                                                                                                                         subscriptionResultHandler: subscriptionResultHandler,
-                                                                                                                                         subscriptionMetadataCache: nil,
-                                                                                                                                         syncConfiguration: syncConfiguration,
-                                                                                                                                         handlerQueue: queue)
-        let syncWithEmptySubscription = AppSyncSubscriptionWithSync<AWSAppSyncClient.EmptySubscription, ListPostsQuery, ListPostsQuery>(appSyncClient: appsyncClient!,
-                                                                                                                                        baseQuery: listPostsQuery,
-                                                                                                                                        deltaQuery: listPostsQuery,
-                                                                                                                                        subscription: emptySubscription,
-                                                                                                                                        baseQueryHandler: listQueryHandler,
-                                                                                                                                        deltaQueryHandler: deltaQueryHandler,
-                                                                                                                                        subscriptionResultHandler: emptySubscriptionResultHandler,
-                                                                                                                                        subscriptionMetadataCache: nil,
-                                                                                                                                        syncConfiguration: syncConfiguration,
-                                                                                                                                        handlerQueue: queue)
+        let syncWithEmptyBaseQuery = AppSyncSubscriptionWithSync(
+            appSyncClient: appsyncClient,
+            baseQuery: emptyQuery,
+            deltaQuery: listPostsQuery,
+            subscription: subscription,
+            baseQueryHandler: emptyQueryHandler,
+            deltaQueryHandler: deltaQueryHandler,
+            subscriptionResultHandler: subscriptionResultHandler,
+            subscriptionMetadataCache: nil,
+            syncConfiguration: syncConfiguration,
+            handlerQueue: queue)
+        
+        let syncWithEmptyDeltaQuery = AppSyncSubscriptionWithSync(
+            appSyncClient: appsyncClient,
+            baseQuery: listPostsQuery,
+            deltaQuery: emptyQuery,
+            subscription: subscription,
+            baseQueryHandler: listQueryHandler,
+            deltaQueryHandler: emptyDeltaQueryHandler,
+            subscriptionResultHandler: subscriptionResultHandler,
+            subscriptionMetadataCache: nil,
+            syncConfiguration: syncConfiguration,
+            handlerQueue: queue)
+        
+        let syncWithEmptySubscription = AppSyncSubscriptionWithSync(
+            appSyncClient: appsyncClient,
+            baseQuery: listPostsQuery,
+            deltaQuery: listPostsQuery,
+            subscription: emptySubscription,
+            baseQueryHandler: listQueryHandler,
+            deltaQueryHandler: deltaQueryHandler,
+            subscriptionResultHandler: emptySubscriptionResultHandler,
+            subscriptionMetadataCache: nil,
+            syncConfiguration: syncConfiguration,
+            handlerQueue: queue)
+        
         let emptyBaseQueryResult = syncWithEmptyBaseQuery.getOperationHash()
         let emptyDeltaQueryResult = syncWithEmptyDeltaQuery.getOperationHash()
         let emptySubscriptionResult = syncWithEmptySubscription.getOperationHash()
@@ -98,37 +108,43 @@ class AppSyncSubscriptionWithSyncTests: XCTestCase {
     }
     
     func testWithTwoEmptyValues() {
-        let syncWithBaseQueryNonNull = AppSyncSubscriptionWithSync<AWSAppSyncClient.EmptySubscription, ListPostsQuery, AWSAppSyncClient.EmptyQuery>(appSyncClient: appsyncClient!,
-                                                                                                                                                    baseQuery: listPostsQuery,
-                                                                                                                                                    deltaQuery: emptyQuery,
-                                                                                                                                                    subscription: emptySubscription,
-                                                                                                                                                    baseQueryHandler: listQueryHandler,
-                                                                                                                                                    deltaQueryHandler: emptyDeltaQueryHandler,
-                                                                                                                                                    subscriptionResultHandler: emptySubscriptionResultHandler,
-                                                                                                                                                    subscriptionMetadataCache: nil,
-                                                                                                                                                    syncConfiguration: syncConfiguration,
-                                                                                                                                                    handlerQueue: queue)
         
-        let syncWithDeltaQueryNonNull = AppSyncSubscriptionWithSync<AWSAppSyncClient.EmptySubscription, AWSAppSyncClient.EmptyQuery, ListPostsQuery>(appSyncClient: appsyncClient!,
-                                                                                                                                                     baseQuery: emptyQuery,
-                                                                                                                                                     deltaQuery: listPostsQuery,
-                                                                                                                                                     subscription: emptySubscription,
-                                                                                                                                                     baseQueryHandler: emptyQueryHandler,
-                                                                                                                                                     deltaQueryHandler: deltaQueryHandler,
-                                                                                                                                                     subscriptionResultHandler: emptySubscriptionResultHandler,
-                                                                                                                                                     subscriptionMetadataCache: nil,
-                                                                                                                                                     syncConfiguration: syncConfiguration,
-                                                                                                                                                     handlerQueue: queue)
-        let syncWithSubscriptionNonNull = AppSyncSubscriptionWithSync<OnUpvotePostSubscription, AWSAppSyncClient.EmptyQuery, AWSAppSyncClient.EmptyQuery>(appSyncClient: appsyncClient!,
-                                                                                                                                                          baseQuery: emptyQuery,
-                                                                                                                                                          deltaQuery: emptyQuery,
-                                                                                                                                                          subscription: subscription,
-                                                                                                                                                          baseQueryHandler: emptyQueryHandler,
-                                                                                                                                                          deltaQueryHandler: emptyDeltaQueryHandler,
-                                                                                                                                                          subscriptionResultHandler: subscriptionResultHandler,
-                                                                                                                                                          subscriptionMetadataCache: nil,
-                                                                                                                                                          syncConfiguration: syncConfiguration,
-                                                                                                                                                          handlerQueue: queue)
+        let syncWithBaseQueryNonNull = AppSyncSubscriptionWithSync(
+            appSyncClient: appsyncClient,
+            baseQuery: listPostsQuery,
+            deltaQuery: emptyQuery,
+            subscription: emptySubscription,
+            baseQueryHandler: listQueryHandler,
+            deltaQueryHandler: emptyDeltaQueryHandler,
+            subscriptionResultHandler: emptySubscriptionResultHandler,
+            subscriptionMetadataCache: nil,
+            syncConfiguration: syncConfiguration,
+            handlerQueue: queue)
+        
+        let syncWithDeltaQueryNonNull = AppSyncSubscriptionWithSync(
+            appSyncClient: appsyncClient,
+            baseQuery: emptyQuery,
+            deltaQuery: listPostsQuery,
+            subscription: emptySubscription,
+            baseQueryHandler: emptyQueryHandler,
+            deltaQueryHandler: deltaQueryHandler,
+            subscriptionResultHandler: emptySubscriptionResultHandler,
+            subscriptionMetadataCache: nil,
+            syncConfiguration: syncConfiguration,
+            handlerQueue: queue)
+        
+        let syncWithSubscriptionNonNull = AppSyncSubscriptionWithSync(
+            appSyncClient: appsyncClient,
+            baseQuery: emptyQuery,
+            deltaQuery: emptyQuery,
+            subscription: subscription,
+            baseQueryHandler: emptyQueryHandler,
+            deltaQueryHandler: emptyDeltaQueryHandler,
+            subscriptionResultHandler: subscriptionResultHandler,
+            subscriptionMetadataCache: nil,
+            syncConfiguration: syncConfiguration,
+            handlerQueue: queue)
+        
         let syncWithBaseQueryNonNullResult = syncWithBaseQueryNonNull.getOperationHash()
         let syncWithDeltaQueryNonNullResult = syncWithDeltaQueryNonNull.getOperationHash()
         let syncWithSubscriptionNonNullResult = syncWithSubscriptionNonNull.getOperationHash()
@@ -137,67 +153,83 @@ class AppSyncSubscriptionWithSyncTests: XCTestCase {
         XCTAssertNotEqual(syncWithBaseQueryNonNullResult, syncWithSubscriptionNonNullResult, "Hash value should be different for the two sync operation")
         XCTAssertNotEqual(syncWithDeltaQueryNonNullResult, syncWithSubscriptionNonNullResult, "Hash value should be different for the two sync operation")
     }
-    
-    
+
     func testWithSameVariablesUnordered() {
-        let subscriptionWithSync1 = AppSyncSubscriptionWithSync<AWSAppSyncClient.EmptySubscription, GraphGetQuery, AWSAppSyncClient.EmptyQuery>(appSyncClient: appsyncClient!,
-                                                                                                                                                baseQuery: getQuery,
-                                                                                                                                                deltaQuery: emptyQuery,
-                                                                                                                                                subscription: emptySubscription,
-                                                                                                                                                baseQueryHandler: getQueryHandler,
-                                                                                                                                                deltaQueryHandler: emptyDeltaQueryHandler,
-                                                                                                                                                subscriptionResultHandler: emptySubscriptionResultHandler,
-                                                                                                                                                subscriptionMetadataCache: nil,
-                                                                                                                                                syncConfiguration: syncConfiguration,
-                                                                                                                                                handlerQueue: queue)
         
-        let subscriptionWithSync2 = AppSyncSubscriptionWithSync<AWSAppSyncClient.EmptySubscription, GraphGetQuery, AWSAppSyncClient.EmptyQuery>(appSyncClient: appsyncClient!,
-                                                                                                                                                baseQuery: getQuery,
-                                                                                                                                                deltaQuery: emptyQuery,
-                                                                                                                                                subscription: emptySubscription,
-                                                                                                                                                baseQueryHandler: getQueryHandler,
-                                                                                                                                                deltaQueryHandler: emptyDeltaQueryHandler,
-                                                                                                                                                subscriptionResultHandler: emptySubscriptionResultHandler,
-                                                                                                                                                subscriptionMetadataCache: nil,
-                                                                                                                                                syncConfiguration: syncConfiguration,
-                                                                                                                                                handlerQueue: queue)
+        let subscriptionWithSync1 = AppSyncSubscriptionWithSync(
+            appSyncClient: appsyncClient,
+            baseQuery: getQuery,
+            deltaQuery: emptyQuery,
+            subscription: emptySubscription,
+            baseQueryHandler: getQueryHandler,
+            deltaQueryHandler: emptyDeltaQueryHandler,
+            subscriptionResultHandler: emptySubscriptionResultHandler,
+            subscriptionMetadataCache: nil,
+            syncConfiguration: syncConfiguration,
+            handlerQueue: queue)
+        
+        let subscriptionWithSync2 = AppSyncSubscriptionWithSync(
+            appSyncClient: appsyncClient,
+            baseQuery: getQuery,
+            deltaQuery: emptyQuery,
+            subscription: emptySubscription,
+            baseQueryHandler: getQueryHandler,
+            deltaQueryHandler: emptyDeltaQueryHandler,
+            subscriptionResultHandler: emptySubscriptionResultHandler,
+            subscriptionMetadataCache: nil,
+            syncConfiguration: syncConfiguration,
+            handlerQueue: queue)
+        
         let result1 = subscriptionWithSync1.getOperationHash()
         let result2 = subscriptionWithSync2.getOperationHash()
         XCTAssertEqual(result1, result2, "Hash value should be equal for the two sync operation")
-        
     }
     
-    
-    private class GraphGetQuery: GraphQLQuery {
-        public static let operationString = "query GetQuery($id: ID!) {\n  getID(id: $id) {\n    __typename\n }\n}"
-        public var id: GraphQLID
+    func testWithSameBaseDeltaQuery() {
         
-        public init(id: GraphQLID) {
-            self.id = id
-        }
+        let subscriptionWithSync = AppSyncSubscriptionWithSync(
+            appSyncClient: appsyncClient,
+            baseQuery: listPostsQuery,
+            deltaQuery: listPostsQuery,
+            subscription: emptySubscription,
+            baseQueryHandler: listQueryHandler,
+            deltaQueryHandler: deltaQueryHandler,
+            subscriptionResultHandler: emptySubscriptionResultHandler,
+            subscriptionMetadataCache: nil,
+            syncConfiguration: syncConfiguration,
+            handlerQueue: queue)
         
-        public var variables: GraphQLMap? {
-            return ["id": id, "id2": "2", "time": "123"]
-        }
-        
-        public struct Data: GraphQLSelectionSet {
-            
-            public var snapshot: Snapshot
-            
-            public init(snapshot: Snapshot) {
-                self.snapshot = snapshot
-            }
-            
-            public static let selections: [GraphQLSelection] = [
-                GraphQLField("getID", arguments: ["id": GraphQLVariable("id")], type: .object(
-                    [
-                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-                        GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self)))
-                    ])),
-            ]
-        }
+        let result = subscriptionWithSync.getOperationHash()
+        XCTAssertNotNil(result, "Should produce a non nil hash when all fields are present.")
     }
 }
 
+private class GraphGetQuery: GraphQLQuery {
+    public static let operationString = "query GetQuery($id: ID!) {\n  getID(id: $id) {\n __typename\n }\n}"
+    public var id: GraphQLID
+    
+    public init(id: GraphQLID) {
+        self.id = id
+    }
+    
+    public var variables: GraphQLMap? {
+        return ["id": id, "id2": "2", "time": "123"]
+    }
+    
+    public struct Data: GraphQLSelectionSet {
 
+        public var snapshot: Snapshot
 
+        public init(snapshot: Snapshot) {
+            self.snapshot = snapshot
+        }
+
+        public static let selections: [GraphQLSelection] = [
+            GraphQLField("getID", arguments: ["id": GraphQLVariable("id")], type: .object(
+                [
+                    GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                    GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self)))
+                ])),
+        ]
+    }
+}

--- a/AWSAppSyncUnitTests/AppSyncSubscriptionWithSyncTests.swift
+++ b/AWSAppSyncUnitTests/AppSyncSubscriptionWithSyncTests.swift
@@ -1,0 +1,203 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Amazon Software License
+// http://aws.amazon.com/asl/
+//
+
+import XCTest
+@testable import AWSAppSync
+@testable import AWSAppSyncTestCommon
+
+class AppSyncSubscriptionWithSyncTests: XCTestCase {
+    
+    var appsyncClient: AWSAppSyncClient?
+    let queue = DispatchQueue.main
+    let syncConfiguration = SyncConfiguration(baseRefreshIntervalInSeconds: 2)
+    
+    let emptyQuery = AWSAppSyncClient.EmptyQuery()
+    let emptyQueryHandler : OperationResultHandler<AWSAppSyncClient.EmptyQuery> = {(_, _) in}
+    
+    let listPostsQuery = ListPostsQuery()
+    let listQueryHandler : OperationResultHandler<ListPostsQuery> = {(_, _) in}
+    
+    private let getQuery = GraphGetQuery(id: "2")
+    private let getQueryHandler : OperationResultHandler<GraphGetQuery> = {(_, _) in}
+    
+    let deltaQueryHandler : DeltaQueryResultHandler<ListPostsQuery> = {(_, _, _) in}
+    let emptyDeltaQueryHandler : DeltaQueryResultHandler<AWSAppSyncClient.EmptyQuery> = {(_, _, _) in}
+    
+    let subscription = OnUpvotePostSubscription(id: UUID().uuidString)
+    let subscriptionResultHandler : SubscriptionResultHandler<OnUpvotePostSubscription> = { (_, _, _) in }
+    
+    let emptySubscription = AWSAppSyncClient.EmptySubscription.init()
+    let emptySubscriptionResultHandler: SubscriptionResultHandler<AWSAppSyncClient.EmptySubscription> = { (_, _, _) in }
+    
+    override func setUp() {
+        do {
+            let mockHTTPTransport = MockAWSNetworkTransport()
+            appsyncClient = try UnitTestHelpers.makeAppSyncClient(using: mockHTTPTransport, cacheConfiguration: AWSAppSyncCacheConfiguration())
+        } catch {
+            XCTFail("Error thrown during initialization: \(error)")
+        }
+    }
+    
+    func testWithAllValuesFilled() {
+        let subscriptionWithSync = AppSyncSubscriptionWithSync<OnUpvotePostSubscription, ListPostsQuery, ListPostsQuery>(appSyncClient: appsyncClient!,
+                                                                                                                         baseQuery: listPostsQuery,
+                                                                                                                         deltaQuery: listPostsQuery,
+                                                                                                                         subscription: subscription,
+                                                                                                                         baseQueryHandler: listQueryHandler,
+                                                                                                                         deltaQueryHandler: deltaQueryHandler,
+                                                                                                                         subscriptionResultHandler: subscriptionResultHandler,
+                                                                                                                         subscriptionMetadataCache: nil,
+                                                                                                                         syncConfiguration: syncConfiguration,
+                                                                                                                         handlerQueue: queue)
+        let result = subscriptionWithSync.getOperationHash()
+        XCTAssertNotNil(result, "Should produce a non nil hash when all fields are present.")
+    }
+    
+    func testWithOneEmptyValue() {
+        
+        let syncWithEmptyBaseQuery = AppSyncSubscriptionWithSync<OnUpvotePostSubscription, AWSAppSyncClient.EmptyQuery, ListPostsQuery>(appSyncClient: appsyncClient!,
+                                                                                                                                        baseQuery: emptyQuery,
+                                                                                                                                        deltaQuery: listPostsQuery,
+                                                                                                                                        subscription: subscription,
+                                                                                                                                        baseQueryHandler: emptyQueryHandler,
+                                                                                                                                        deltaQueryHandler: deltaQueryHandler,
+                                                                                                                                        subscriptionResultHandler: subscriptionResultHandler,
+                                                                                                                                        subscriptionMetadataCache: nil,
+                                                                                                                                        syncConfiguration: syncConfiguration,
+                                                                                                                                        handlerQueue: queue)
+        let syncWithEmptyDeltaQuery = AppSyncSubscriptionWithSync<OnUpvotePostSubscription, ListPostsQuery, AWSAppSyncClient.EmptyQuery>(appSyncClient: appsyncClient!,
+                                                                                                                                         baseQuery: listPostsQuery,
+                                                                                                                                         deltaQuery: emptyQuery,
+                                                                                                                                         subscription: subscription,
+                                                                                                                                         baseQueryHandler: listQueryHandler,
+                                                                                                                                         deltaQueryHandler: emptyDeltaQueryHandler,
+                                                                                                                                         subscriptionResultHandler: subscriptionResultHandler,
+                                                                                                                                         subscriptionMetadataCache: nil,
+                                                                                                                                         syncConfiguration: syncConfiguration,
+                                                                                                                                         handlerQueue: queue)
+        let syncWithEmptySubscription = AppSyncSubscriptionWithSync<AWSAppSyncClient.EmptySubscription, ListPostsQuery, ListPostsQuery>(appSyncClient: appsyncClient!,
+                                                                                                                                        baseQuery: listPostsQuery,
+                                                                                                                                        deltaQuery: listPostsQuery,
+                                                                                                                                        subscription: emptySubscription,
+                                                                                                                                        baseQueryHandler: listQueryHandler,
+                                                                                                                                        deltaQueryHandler: deltaQueryHandler,
+                                                                                                                                        subscriptionResultHandler: emptySubscriptionResultHandler,
+                                                                                                                                        subscriptionMetadataCache: nil,
+                                                                                                                                        syncConfiguration: syncConfiguration,
+                                                                                                                                        handlerQueue: queue)
+        let emptyBaseQueryResult = syncWithEmptyBaseQuery.getOperationHash()
+        let emptyDeltaQueryResult = syncWithEmptyDeltaQuery.getOperationHash()
+        let emptySubscriptionResult = syncWithEmptySubscription.getOperationHash()
+        
+        XCTAssertNotEqual(emptyBaseQueryResult, emptyDeltaQueryResult, "Hash value should be different for the two sync operation")
+        XCTAssertNotEqual(emptyBaseQueryResult, emptySubscriptionResult, "Hash value should be different for the two sync operation")
+        XCTAssertNotEqual(emptyDeltaQueryResult, emptySubscriptionResult, "Hash value should be different for the two sync operation")
+    }
+    
+    func testWithTwoEmptyValues() {
+        let syncWithBaseQueryNonNull = AppSyncSubscriptionWithSync<AWSAppSyncClient.EmptySubscription, ListPostsQuery, AWSAppSyncClient.EmptyQuery>(appSyncClient: appsyncClient!,
+                                                                                                                                                    baseQuery: listPostsQuery,
+                                                                                                                                                    deltaQuery: emptyQuery,
+                                                                                                                                                    subscription: emptySubscription,
+                                                                                                                                                    baseQueryHandler: listQueryHandler,
+                                                                                                                                                    deltaQueryHandler: emptyDeltaQueryHandler,
+                                                                                                                                                    subscriptionResultHandler: emptySubscriptionResultHandler,
+                                                                                                                                                    subscriptionMetadataCache: nil,
+                                                                                                                                                    syncConfiguration: syncConfiguration,
+                                                                                                                                                    handlerQueue: queue)
+        
+        let syncWithDeltaQueryNonNull = AppSyncSubscriptionWithSync<AWSAppSyncClient.EmptySubscription, AWSAppSyncClient.EmptyQuery, ListPostsQuery>(appSyncClient: appsyncClient!,
+                                                                                                                                                     baseQuery: emptyQuery,
+                                                                                                                                                     deltaQuery: listPostsQuery,
+                                                                                                                                                     subscription: emptySubscription,
+                                                                                                                                                     baseQueryHandler: emptyQueryHandler,
+                                                                                                                                                     deltaQueryHandler: deltaQueryHandler,
+                                                                                                                                                     subscriptionResultHandler: emptySubscriptionResultHandler,
+                                                                                                                                                     subscriptionMetadataCache: nil,
+                                                                                                                                                     syncConfiguration: syncConfiguration,
+                                                                                                                                                     handlerQueue: queue)
+        let syncWithSubscriptionNonNull = AppSyncSubscriptionWithSync<OnUpvotePostSubscription, AWSAppSyncClient.EmptyQuery, AWSAppSyncClient.EmptyQuery>(appSyncClient: appsyncClient!,
+                                                                                                                                                          baseQuery: emptyQuery,
+                                                                                                                                                          deltaQuery: emptyQuery,
+                                                                                                                                                          subscription: subscription,
+                                                                                                                                                          baseQueryHandler: emptyQueryHandler,
+                                                                                                                                                          deltaQueryHandler: emptyDeltaQueryHandler,
+                                                                                                                                                          subscriptionResultHandler: subscriptionResultHandler,
+                                                                                                                                                          subscriptionMetadataCache: nil,
+                                                                                                                                                          syncConfiguration: syncConfiguration,
+                                                                                                                                                          handlerQueue: queue)
+        let syncWithBaseQueryNonNullResult = syncWithBaseQueryNonNull.getOperationHash()
+        let syncWithDeltaQueryNonNullResult = syncWithDeltaQueryNonNull.getOperationHash()
+        let syncWithSubscriptionNonNullResult = syncWithSubscriptionNonNull.getOperationHash()
+        
+        XCTAssertNotEqual(syncWithBaseQueryNonNullResult, syncWithDeltaQueryNonNullResult, "Hash value should be different for the two sync operation")
+        XCTAssertNotEqual(syncWithBaseQueryNonNullResult, syncWithSubscriptionNonNullResult, "Hash value should be different for the two sync operation")
+        XCTAssertNotEqual(syncWithDeltaQueryNonNullResult, syncWithSubscriptionNonNullResult, "Hash value should be different for the two sync operation")
+    }
+    
+    
+    func testWithSameVariablesUnordered() {
+        let subscriptionWithSync1 = AppSyncSubscriptionWithSync<AWSAppSyncClient.EmptySubscription, GraphGetQuery, AWSAppSyncClient.EmptyQuery>(appSyncClient: appsyncClient!,
+                                                                                                                                                baseQuery: getQuery,
+                                                                                                                                                deltaQuery: emptyQuery,
+                                                                                                                                                subscription: emptySubscription,
+                                                                                                                                                baseQueryHandler: getQueryHandler,
+                                                                                                                                                deltaQueryHandler: emptyDeltaQueryHandler,
+                                                                                                                                                subscriptionResultHandler: emptySubscriptionResultHandler,
+                                                                                                                                                subscriptionMetadataCache: nil,
+                                                                                                                                                syncConfiguration: syncConfiguration,
+                                                                                                                                                handlerQueue: queue)
+        
+        let subscriptionWithSync2 = AppSyncSubscriptionWithSync<AWSAppSyncClient.EmptySubscription, GraphGetQuery, AWSAppSyncClient.EmptyQuery>(appSyncClient: appsyncClient!,
+                                                                                                                                                baseQuery: getQuery,
+                                                                                                                                                deltaQuery: emptyQuery,
+                                                                                                                                                subscription: emptySubscription,
+                                                                                                                                                baseQueryHandler: getQueryHandler,
+                                                                                                                                                deltaQueryHandler: emptyDeltaQueryHandler,
+                                                                                                                                                subscriptionResultHandler: emptySubscriptionResultHandler,
+                                                                                                                                                subscriptionMetadataCache: nil,
+                                                                                                                                                syncConfiguration: syncConfiguration,
+                                                                                                                                                handlerQueue: queue)
+        let result1 = subscriptionWithSync1.getOperationHash()
+        let result2 = subscriptionWithSync2.getOperationHash()
+        XCTAssertEqual(result1, result2, "Hash value should be equal for the two sync operation")
+        
+    }
+    
+    
+    private class GraphGetQuery: GraphQLQuery {
+        public static let operationString = "query GetQuery($id: ID!) {\n  getID(id: $id) {\n    __typename\n }\n}"
+        public var id: GraphQLID
+        
+        public init(id: GraphQLID) {
+            self.id = id
+        }
+        
+        public var variables: GraphQLMap? {
+            return ["id": id, "id2": "2", "time": "123"]
+        }
+        
+        public struct Data: GraphQLSelectionSet {
+            
+            public var snapshot: Snapshot
+            
+            public init(snapshot: Snapshot) {
+                self.snapshot = snapshot
+            }
+            
+            public static let selections: [GraphQLSelection] = [
+                GraphQLField("getID", arguments: ["id": GraphQLVariable("id")], type: .object(
+                    [
+                        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                        GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self)))
+                    ])),
+            ]
+        }
+    }
+}
+
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The AWS AppSync SDK for iOS enables you to access your AWS AppSync backend and perform operations like `Queries`, `Mutations` and `Subscriptions`. The SDK
 also includes support for offline operations.
 
+## 2.14.0
+
+### Bug Fixes
+
+* Fix bug where delta sync was not working as intended. See [issue #232](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/232)
+* **Breaking API Change** To fix the delta sync logic, there was a change in the hashing function used internally. This change can cause the existing app to ignore the cache for the first sync and fetch data using basequery. Subsequent sync operaton shoudl work as normal.
+
 ## 2.13.1
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ also includes support for offline operations.
 
 ### Bug Fixes
 
-* Fix bug where delta sync was not working as intended. See [issue #232](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/232)
+* Fix a bug where delta sync was not correctly storing/ retrieving the `lastSyncTime`. See [issue #232](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/232)
 * **Breaking API Change** To fix the delta sync logic, there was a change in the hashing function used internally. This change can cause the existing app to ignore the cache for the first sync and fetch data using base query. Subsequent sync operation should work as normal.
 
 ## 2.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ also includes support for offline operations.
 ### Bug Fixes
 
 * Fix bug where delta sync was not working as intended. See [issue #232](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/232)
-* **Breaking API Change** To fix the delta sync logic, there was a change in the hashing function used internally. This change can cause the existing app to ignore the cache for the first sync and fetch data using basequery. Subsequent sync operaton shoudl work as normal.
+* **Breaking API Change** To fix the delta sync logic, there was a change in the hashing function used internally. This change can cause the existing app to ignore the cache for the first sync and fetch data using base query. Subsequent sync operation should work as normal.
 
 ## 2.13.1
 


### PR DESCRIPTION
Delta sync was using wrong hash to store the data in the local cache. This caused
delta sync to fail intermittently.

*Issue #:* 
#232 

*Description of changes:* 
Hash calculation used in delta calculation was wrong and was producing different results on the same input. This was caused due to the unordered representation of swift Dictionary object which we used for creating hash. This PR addresses this issue by sorting the dictionary content and then using it for hash calculation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
