### PR TITLE
Palpatim/mqtt decoder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_deploy:
 - carthage build --no-skip-current
 - carthage archive $FRAMEWORK_NAME
 script:
-- xcodebuild -quiet -workspace AWSAppSyncClient.xcworkspace -scheme AWSAppSync build test -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest'
+- xcodebuild -quiet -workspace AWSAppSyncClient.xcworkspace -scheme AWSAppSync build test -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest'
 deploy:
 - provider: releases
   api_key:


### PR DESCRIPTION
*Issue #, if available:*

Ports the MQTTDecoder fixes from https://github.com/aws-amplify/aws-sdk-ios/pull/2007 to the AppSync MQTT SDK.

We haven't completely determined that live customers are encountering this situation, but this is a stability enhancement that we should put in place for the MQTT transport layer.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
