### PR TITLE
Fix strong retain cycles

### DIFF
--- a/AWSAppSyncClient/Internal/AppSyncSubscriptionWithSync.swift
+++ b/AWSAppSyncClient/Internal/AppSyncSubscriptionWithSync.swift
@@ -102,11 +102,11 @@ final class AppSyncSubscriptionWithSync<Subscription: GraphQLSubscription, BaseQ
 
     private func performInitialSync() {
         AppSyncLog.debug("Queuing operations for initial sync")
-        internalStateSyncQueue.addOperation {
-            self.registerForNotifications()
-            self.initializeLastSyncTimeFromCache()
-            self.initializeBaseQueryResultsFromCache()
-            self.performSync()
+        internalStateSyncQueue.addOperation { [weak self] in
+            self?.registerForNotifications()
+            self?.initializeLastSyncTimeFromCache()
+            self?.initializeBaseQueryResultsFromCache()
+            self?.performSync()
         }
     }
 
@@ -475,11 +475,11 @@ final class AppSyncSubscriptionWithSync<Subscription: GraphQLSubscription, BaseQ
             return
         }
 
-        nextSyncTimer = DispatchSource.makeOneOffDispatchSourceTimer(deadline: deadline, queue: handlerQueue) {
+        nextSyncTimer = DispatchSource.makeOneOffDispatchSourceTimer(deadline: deadline, queue: handlerQueue) { [weak self] in
             AppSyncLog.debug("Timer fired, queueing sync operation")
-            self.internalStateSyncQueue.addOperation {
+            self?.internalStateSyncQueue.addOperation {
                 AppSyncLog.debug("Perform sync queued by timer")
-                self.performSync()
+                self?.performSync()
             }
         }
 

--- a/AWSAppSyncIntegrationTests/SubscriptionTests.swift
+++ b/AWSAppSyncIntegrationTests/SubscriptionTests.swift
@@ -268,29 +268,22 @@ class SubscriptionTests: XCTestCase {
             watchersWhichShouldNotReceiveCallbackExpectation.fulfill()
         }
         
-        
-        // we create a dictionary where we hold all the watchers; this mimicks app holding reference to watchers
-        var watchers: [String: AWSAppSyncSubscriptionWatcher<OnUpvotePostSubscription>] = [:]
-        
+        // Initiate subscription requests for the generated object ids
+        for _ in 0 ..< subscriptionWatchers {
+            let watcher = try! appSyncClient.subscribe(subscription: OnUpvotePostSubscription(id: "123"),
+                                                       statusChangeHandler: statusChangeHandlerNoUpdates) { _, _, _ in }
+            // Immediately cancel subscription (before delayed http callback which we implemented above can be executed.)
+            watcher?.cancel()
+        }
+
         // create an array of object ids to be used in subscription
         var subscriptionIds: [String] = []
         for _ in 0 ..< subscriptionWatchers  {
             subscriptionIds.append(UUID().uuidString)
         }
-        
-        // Initiate subscription requests for the generated object ids
-        for uuid in subscriptionIds {
-            let watcher = try! appSyncClient.subscribe(subscription: OnUpvotePostSubscription(id: "123"),
-                                                       statusChangeHandler: statusChangeHandlerNoUpdates) { _, _, _ in }
-            watchers[uuid] = watcher
-        }
-        
-        // Immediately cancel all subscriptions (before delayed http callback which we implemented above can be executed.)
-        for uuid in subscriptionIds {
-            watchers[uuid]?.cancel()
-        }
-        // Remove references
-        watchers.removeAll()
+
+        // we create a dictionary where we hold all the watchers; this mimicks app holding reference to watchers
+        var watchers: [String: AWSAppSyncSubscriptionWatcher<OnUpvotePostSubscription>] = [:]
         
         // Try starting the subscriptions again
         for uuid in subscriptionIds {

--- a/AWSAppSyncUnitTests/AppSyncSubscriptionWithSyncTests.swift
+++ b/AWSAppSyncUnitTests/AppSyncSubscriptionWithSyncTests.swift
@@ -215,12 +215,13 @@ class AppSyncSubscriptionWithSyncTests: XCTestCase {
             subscriptionMetadataCache: nil,
             syncConfiguration: .init(baseRefreshIntervalInSeconds: 1),
             handlerQueue: queue)
+        XCTAssertNotNil(subscriptionWithSync, "subscriptionWithSync should return an initialized object")
 
         weak var weakRef = subscriptionWithSync
         subscriptionWithSync?.cancel()
         subscriptionWithSync = nil
         let expectation = XCTestExpectation(description: "subscriptionWithSync reference deinitialized")
-        DispatchQueue.main.async {
+        DispatchQueue(label: "com.aws.subscriptionWithSync.dispatch", qos: .background).async {
             while true {
                 if weakRef == nil {
                     expectation.fulfill()


### PR DESCRIPTION
*Issue #342:*

*Description of changes:*
Takes a `weak self` reference inside of the initial sync operation and dispatch timer for sync.

The integration test  `testDeltaSyncMetadataClear` had to be updated to take a strong reference of the `Cancellable` objects.

The integration test `testStartStopStartSubscriptions` also had to be updated, although this appeared to be failing previous to the changes provided here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
