### PR TITLE
Update podspec to include refactored folder structure

### DIFF
--- a/AWSAppSync.podspec
+++ b/AWSAppSync.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.dependency 'ReachabilitySwift', '~> 5.0.0'
   s.dependency 'AppSyncRealTimeClient', '~> 1.0.0'
 
-  s.source_files = 'AWSAppSyncClient/AWSAppSync.h', 'AWSAppSyncClient/*.swift', 'AWSAppSyncClient/Internal/*.swift', 'AWSAppSyncClient/Subscription/**/*.swift', 'AWSAppSyncClient/Apollo/Sources/Apollo/*.swift', 'AWSAppSyncClient/Internal/*.{h,m}'
+  s.source_files = 'AWSAppSyncClient/AWSAppSync.h', 'AWSAppSyncClient/*.swift', 'AWSAppSyncClient/Internal/*.swift', 'AWSAppSyncClient/SubscriptionFactory/**/*.swift', 'AWSAppSyncClient/AuthInterceptor/**/*.swift', 'AWSAppSyncClient/Apollo/Sources/Apollo/*.swift', 'AWSAppSyncClient/Internal/*.{h,m}'
   s.public_header_files = ['AWSAppSyncClient/AWSAppSync.h', 'AWSAppSyncClient/AWSAppSync-Swift.h', 'AWSAppSyncClient/Internal/AppSyncLogHelper.h']
 end


### PR DESCRIPTION
update podspec to include refactored folder structure (subscriptionfactory and authinterceptor)

on newly checked out repo, was able to reproduce 
```
    - ERROR | [iOS] xcodebuild:  AWSAppSync/AWSAppSyncClient/AWSAppSyncClient.swift:41:40: error: use of undeclared type 'SubscriptionConnectionFactory'
[!] The spec did not pass validation, due to 4 errors and 31 warnings.
```

from the code refactoring, i moved out Subscription folder and created the two SubscriptionFactory and AuthInterceptor folders. 

re run pod spec lint no longer have errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
