### PR TITLE
Use AppSyncRealTimeClient 1.1.0

### DIFF
--- a/AWSAppSync.podspec
+++ b/AWSAppSync.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.dependency 'AWSCore', '~> 2.12.0'
   s.dependency 'SQLite.swift', '~> 0.12.2'
   s.dependency 'ReachabilitySwift', '~> 5.0.0'
-  s.dependency 'AppSyncRealTimeClient', '~> 1.0.2'
+  s.dependency 'AppSyncRealTimeClient', '~> 1.1.0'
 
   s.source_files = 'AWSAppSyncClient/AWSAppSync.h', 'AWSAppSyncClient/*.swift', 'AWSAppSyncClient/Internal/**/*.{h,m,swift}', 'AWSAppSyncClient/Apollo/Sources/Apollo/*.swift'
   s.public_header_files = ['AWSAppSyncClient/AWSAppSync.h', 'AWSAppSyncClient/AWSAppSync-Swift.h', 'AWSAppSyncClient/Internal/AppSyncLogHelper.h']

--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,7 @@ target "AWSAppSync" do
   pod "AWSCore", "~> #{AWS_SDK_VERSION}"
   pod "SQLite.swift", "~> 0.12.2"
   pod "ReachabilitySwift", "~> 5.0.0"
-  pod "AppSyncRealTimeClient", "~> 1.0.2"
+  pod "AppSyncRealTimeClient", "~> 1.1.0"
 end
 
 target "AWSAppSyncTestCommon" do
@@ -18,7 +18,7 @@ target "AWSAppSyncTestCommon" do
   # We directly access a database connection to verify certain initialization
   # setups
   pod "SQLite.swift", "~> 0.12.2"
-  pod "AppSyncRealTimeClient", "~> 1.0.2"
+  pod "AppSyncRealTimeClient", "~> 1.1.0"
 end
 
 target "AWSAppSyncTestApp" do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AppSyncRealTimeClient (1.0.2):
+  - AppSyncRealTimeClient (1.1.0):
     - Starscream (~> 3.0.2)
   - AWSAuthCore (2.12.7):
     - AWSCore (= 2.12.7)
@@ -20,7 +20,7 @@ PODS:
   - Starscream (3.0.6)
 
 DEPENDENCIES:
-  - AppSyncRealTimeClient (~> 1.0.2)
+  - AppSyncRealTimeClient (~> 1.1.0)
   - AWSCore (~> 2.12.0)
   - AWSMobileClient (~> 2.12.0)
   - AWSS3 (~> 2.12.0)
@@ -42,7 +42,7 @@ SPEC REPOS:
     - SQLite.swift
 
 SPEC CHECKSUMS:
-  AppSyncRealTimeClient: b2bb68358d28dc4633ab771314e38eb24077a24e
+  AppSyncRealTimeClient: d674396c95e8cac7b7def195f903c586351c3ff4
   AWSAuthCore: 288cb737a35ff031fbf42edaa8d0062328791d4e
   AWSCognitoIdentityProvider: 4998bdbfbafe5038dae0237a598580e102e7b6b5
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
@@ -53,6 +53,6 @@ SPEC CHECKSUMS:
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
 
-PODFILE CHECKSUM: eff73b52e6a612b4e1a27550a443bc931b115eae
+PODFILE CHECKSUM: dae7995c2cdf9aa7cc6b4bfc196e4f217b099075
 
 COCOAPODS: 1.9.0

--- a/Pods/AppSyncRealTimeClient/AppSyncRealTimeClient/Interceptor/RealtimeGatewayURLInterceptor.swift
+++ b/Pods/AppSyncRealTimeClient/AppSyncRealTimeClient/Interceptor/RealtimeGatewayURLInterceptor.swift
@@ -8,9 +8,13 @@
 import Foundation
 
 /// Connection interceptor for real time connection provider
-class RealtimeGatewayURLInterceptor: ConnectionInterceptor {
+public class RealtimeGatewayURLInterceptor: ConnectionInterceptor {
 
-    func interceptConnection(_ request: AppSyncConnectionRequest,
+    public init() {
+
+    }
+    
+    public func interceptConnection(_ request: AppSyncConnectionRequest,
                              for endpoint: URL) -> AppSyncConnectionRequest {
         guard let host = endpoint.host else {
             return request

--- a/Pods/AppSyncRealTimeClient/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
+++ b/Pods/AppSyncRealTimeClient/AppSyncRealTimeClient/Websocket/Starscream/StarscreamAdapter.swift
@@ -21,6 +21,7 @@ public class StarscreamAdapter: AppSyncWebsocketProvider {
         socket = WebSocket(url: url, protocols: protocols)
         self.delegate = delegate
         socket?.delegate = self
+        socket?.callbackQueue = DispatchQueue(label: "com.amazonaws.StarscreamAdapter.callBack")
         socket?.connect()
     }
 

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AppSyncRealTimeClient (1.0.2):
+  - AppSyncRealTimeClient (1.1.0):
     - Starscream (~> 3.0.2)
   - AWSAuthCore (2.12.7):
     - AWSCore (= 2.12.7)
@@ -20,7 +20,7 @@ PODS:
   - Starscream (3.0.6)
 
 DEPENDENCIES:
-  - AppSyncRealTimeClient (~> 1.0.2)
+  - AppSyncRealTimeClient (~> 1.1.0)
   - AWSCore (~> 2.12.0)
   - AWSMobileClient (~> 2.12.0)
   - AWSS3 (~> 2.12.0)
@@ -42,7 +42,7 @@ SPEC REPOS:
     - SQLite.swift
 
 SPEC CHECKSUMS:
-  AppSyncRealTimeClient: b2bb68358d28dc4633ab771314e38eb24077a24e
+  AppSyncRealTimeClient: d674396c95e8cac7b7def195f903c586351c3ff4
   AWSAuthCore: 288cb737a35ff031fbf42edaa8d0062328791d4e
   AWSCognitoIdentityProvider: 4998bdbfbafe5038dae0237a598580e102e7b6b5
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
@@ -53,6 +53,6 @@ SPEC CHECKSUMS:
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
 
-PODFILE CHECKSUM: eff73b52e6a612b4e1a27550a443bc931b115eae
+PODFILE CHECKSUM: dae7995c2cdf9aa7cc6b4bfc196e4f217b099075
 
 COCOAPODS: 1.9.0

--- a/Pods/Target Support Files/AppSyncRealTimeClient/AppSyncRealTimeClient-Info.plist
+++ b/Pods/Target Support Files/AppSyncRealTimeClient/AppSyncRealTimeClient-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.0.2</string>
+  <string>1.1.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>


### PR DESCRIPTION
*Issue #, if available:*

Looks like 1.0.2 removed interceptors while current version takes ~1.0.0 which will pulls in 1.0.2 and has some classes missing like `RealtimeGatewayURLInterceptor`. I published `1.1.0` and need to bump the version of the consumers.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
