### PR TITLE
Add "aws-appsync-realtime-client-ios" in cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -2,3 +2,4 @@ github "aws/aws-sdk-ios" ~> 2.12.0
 github "stephencelis/SQLite.swift" ~> 0.12.2
 github "ashleymills/Reachability.swift" ~> 5.0.0
 github "daltoniam/starscream" ~> 3.0.2
+github "aws-amplify/aws-appsync-realtime-client-ios" ~> 1.0.1


### PR DESCRIPTION
Hi everyone.

Please accept this PR in order to include "aws-appsync-realtime-client-ios" in the Cartfile.

"AWSAppSync" framework depends on "aws-appsync-realtime-client-ios" and it was not included in the Cartfile.

Right now, my team can't use the version 3.0.2 using Carthage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.