### PR TITLE
Use AppSyncRealTimeClient 1.2.0 And Carthage fix

### DIFF
--- a/AWSAppSync.podspec
+++ b/AWSAppSync.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.dependency 'AWSCore', '~> 2.13.0'
   s.dependency 'SQLite.swift', '~> 0.12.2'
   s.dependency 'ReachabilitySwift', '~> 5.0.0'
-  s.dependency 'AppSyncRealTimeClient', '~> 1.1.0'
+  s.dependency 'AppSyncRealTimeClient', '~> 1.2.0'
 
   s.source_files = 'AWSAppSyncClient/AWSAppSync.h', 'AWSAppSyncClient/*.swift', 'AWSAppSyncClient/Internal/**/*.{h,m,swift}', 'AWSAppSyncClient/Apollo/Sources/Apollo/*.swift'
   s.public_header_files = ['AWSAppSyncClient/AWSAppSync.h', 'AWSAppSyncClient/AWSAppSync-Swift.h', 'AWSAppSyncClient/Internal/AppSyncLogHelper.h']

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "aws/aws-sdk-ios" ~> 2.13.0
 github "stephencelis/SQLite.swift" ~> 0.12.2
 github "ashleymills/Reachability.swift" ~> 5.0.0
-github "daltoniam/starscream" ~> 3.0.2
+github "aws-amplify/aws-appsync-realtime-client" ~> 1.2.0

--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,7 @@ target "AWSAppSync" do
   pod "AWSCore", "~> #{AWS_SDK_VERSION}"
   pod "SQLite.swift", "~> 0.12.2"
   pod "ReachabilitySwift", "~> 5.0.0"
-  pod "AppSyncRealTimeClient", "~> 1.1.0"
+  pod "AppSyncRealTimeClient", "~> 1.2.0"
 end
 
 target "AWSAppSyncTestCommon" do
@@ -18,7 +18,7 @@ target "AWSAppSyncTestCommon" do
   # We directly access a database connection to verify certain initialization
   # setups
   pod "SQLite.swift", "~> 0.12.2"
-  pod "AppSyncRealTimeClient", "~> 1.1.0"
+  pod "AppSyncRealTimeClient", "~> 1.2.0"
 end
 
 target "AWSAppSyncTestApp" do


### PR DESCRIPTION
This is pending AppSyncRealTimeClient 1.2.0 release (Pods and cartfile update, over in https://github.com/aws-amplify/aws-appsync-realtime-client-ios/pull/9)

After AppSyncRealTimeClient 1.2.0 is tagged/released then this PR needs to be updated with
1. `pod install` to get the 1.2.0 pod files under `Pod/` since they are checked in
2. Test out Carthage process to ensure consumers can use AppSync which depends on AppSyncRealTimeClient, and no longer StarScream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
