### PR TITLE
AppSyncRealTimeClient ~> 1.1 + Cartfile fix

### DIFF
--- a/AWSAppSync.podspec
+++ b/AWSAppSync.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.dependency 'AWSCore', '~> 2.13.0'
   s.dependency 'SQLite.swift', '~> 0.12.2'
   s.dependency 'ReachabilitySwift', '~> 5.0.0'
-  s.dependency 'AppSyncRealTimeClient', '~> 1.1.0'
+  s.dependency 'AppSyncRealTimeClient', '~> 1.1'
 
   s.source_files = 'AWSAppSyncClient/AWSAppSync.h', 'AWSAppSyncClient/*.swift', 'AWSAppSyncClient/Internal/**/*.{h,m,swift}', 'AWSAppSyncClient/Apollo/Sources/Apollo/*.swift'
   s.public_header_files = ['AWSAppSyncClient/AWSAppSync.h', 'AWSAppSyncClient/AWSAppSync-Swift.h', 'AWSAppSyncClient/Internal/AppSyncLogHelper.h']

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "aws/aws-sdk-ios" ~> 2.13.0
 github "stephencelis/SQLite.swift" ~> 0.12.2
 github "ashleymills/Reachability.swift" ~> 5.0.0
-github "aws-amplify/aws-appsync-realtime-client" ~> 1.1
+github "aws-amplify/aws-appsync-realtime-client-ios" ~> 1.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 github "aws/aws-sdk-ios" ~> 2.13.0
 github "stephencelis/SQLite.swift" ~> 0.12.2
 github "ashleymills/Reachability.swift" ~> 5.0.0
-github "daltoniam/starscream" ~> 3.0.2
+github "aws-amplify/aws-appsync-realtime-client" ~> 1.1

--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,7 @@ target "AWSAppSync" do
   pod "AWSCore", "~> #{AWS_SDK_VERSION}"
   pod "SQLite.swift", "~> 0.12.2"
   pod "ReachabilitySwift", "~> 5.0.0"
-  pod "AppSyncRealTimeClient", "~> 1.1.0"
+  pod "AppSyncRealTimeClient", "~> 1.1"
 end
 
 target "AWSAppSyncTestCommon" do
@@ -18,7 +18,7 @@ target "AWSAppSyncTestCommon" do
   # We directly access a database connection to verify certain initialization
   # setups
   pod "SQLite.swift", "~> 0.12.2"
-  pod "AppSyncRealTimeClient", "~> 1.1.0"
+  pod "AppSyncRealTimeClient", "~> 1.1"
 end
 
 target "AWSAppSyncTestApp" do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - AppSyncRealTimeClient (1.1.0):
-    - Starscream (~> 3.0.2)
+  - AppSyncRealTimeClient (1.1.5):
+    - Starscream (= 3.0.6)
   - AWSAuthCore (2.13.0):
     - AWSCore (= 2.13.0)
   - AWSCognitoIdentityProvider (2.13.0):
@@ -20,7 +20,7 @@ PODS:
   - Starscream (3.0.6)
 
 DEPENDENCIES:
-  - AppSyncRealTimeClient (~> 1.1.0)
+  - AppSyncRealTimeClient (~> 1.1)
   - AWSCore (~> 2.13.0)
   - AWSMobileClient (~> 2.13.0)
   - AWSS3 (~> 2.13.0)
@@ -36,13 +36,12 @@ SPEC REPOS:
     - AWSCore
     - AWSMobileClient
     - AWSS3
-    - Starscream
-  trunk:
     - ReachabilitySwift
     - SQLite.swift
+    - Starscream
 
 SPEC CHECKSUMS:
-  AppSyncRealTimeClient: d674396c95e8cac7b7def195f903c586351c3ff4
+  AppSyncRealTimeClient: 610da868f8c56539a840ee848f968120a07a7b6f
   AWSAuthCore: 8fa7f8a8ddd6b0922d9989d8eaa8e7bac87b02fc
   AWSCognitoIdentityProvider: 9ea197104d3425eed78c58d122190217f2b0cee2
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
@@ -53,6 +52,6 @@ SPEC CHECKSUMS:
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
 
-PODFILE CHECKSUM: 1981d2804bde51a39f83dd5bf7719a4849c4aff2
+PODFILE CHECKSUM: 7f76d16b05ca8f9f88f1c8340f8ae2e2c6a920ce
 
 COCOAPODS: 1.9.0

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -1,6 +1,6 @@
 PODS:
-  - AppSyncRealTimeClient (1.1.0):
-    - Starscream (~> 3.0.2)
+  - AppSyncRealTimeClient (1.1.5):
+    - Starscream (= 3.0.6)
   - AWSAuthCore (2.13.0):
     - AWSCore (= 2.13.0)
   - AWSCognitoIdentityProvider (2.13.0):
@@ -20,7 +20,7 @@ PODS:
   - Starscream (3.0.6)
 
 DEPENDENCIES:
-  - AppSyncRealTimeClient (~> 1.1.0)
+  - AppSyncRealTimeClient (~> 1.1)
   - AWSCore (~> 2.13.0)
   - AWSMobileClient (~> 2.13.0)
   - AWSS3 (~> 2.13.0)
@@ -36,13 +36,12 @@ SPEC REPOS:
     - AWSCore
     - AWSMobileClient
     - AWSS3
-    - Starscream
-  trunk:
     - ReachabilitySwift
     - SQLite.swift
+    - Starscream
 
 SPEC CHECKSUMS:
-  AppSyncRealTimeClient: d674396c95e8cac7b7def195f903c586351c3ff4
+  AppSyncRealTimeClient: 610da868f8c56539a840ee848f968120a07a7b6f
   AWSAuthCore: 8fa7f8a8ddd6b0922d9989d8eaa8e7bac87b02fc
   AWSCognitoIdentityProvider: 9ea197104d3425eed78c58d122190217f2b0cee2
   AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
@@ -53,6 +52,6 @@ SPEC CHECKSUMS:
   SQLite.swift: d2b4642190917051ce6bd1d49aab565fe794eea3
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
 
-PODFILE CHECKSUM: 1981d2804bde51a39f83dd5bf7719a4849c4aff2
+PODFILE CHECKSUM: 7f76d16b05ca8f9f88f1c8340f8ae2e2c6a920ce
 
 COCOAPODS: 1.9.0

--- a/Pods/Target Support Files/AppSyncRealTimeClient/AppSyncRealTimeClient-Info.plist
+++ b/Pods/Target Support Files/AppSyncRealTimeClient/AppSyncRealTimeClient-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.1.0</string>
+  <string>1.1.5</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ The AWS AppSync SDK for iOS enables you to access your AWS AppSync backend and p
     * AWSCore.framework
     * Reachability.framework
     * SQLite.framework
+    * AppSyncRealTimeClient.framework
+    * Starscream.framework
 
     Do not select the `Destination: Copy items` if needed check box when prompted.
 


### PR DESCRIPTION
**Update AppSyncRealTimeClient Dependency to ~> 1.1**
This is updated in both the cartfile and the podspec/podfile to take all minor versions from 1.1 up to and not including 2.0 of AppSyncRealTimeClient

**cartfile fix**
The Cartfile located at the root of the AppSyncClient repository is used when users run `carthage update` to determine which additional dependencies are needed. The reason for this is because AppSyncClient is managed by Cocoapods via Podfile. If AppSyncClient doesn't have a Cartfile, then the Carthage users in their projects containing a cartfile with `github "awslabs/aws-mobile-appsync-sdk-ios"` will just pull in AppSync source and build the AppSyncClient.framework and nothing else.

**Remove daltoniam/starscream for aws-amplify/aws-appsync-realtime-client-ios**
Since aws-amplify/aws-appsync-realtime-client-ios itself is a repository that is managed by Pods, it also has a Cartfile indicating that it will need to pull in Starscream. So users pulling in aws-appsync-realtime-client-ios via cartfile will also pull in starscream.

**Testing done**
A new project with cartfile
`github "awslabs/aws-mobile-appsync-sdk-ios" "feature/carthage"`

then `carthage update --platform iOS` pulls in the required dependencies.

Cartfile.resolved contains:
```
github "ashleymills/Reachability.swift" "v5.0.0"
github "aws-amplify/aws-appsync-realtime-client-ios" "1.1.5"
github "aws/aws-sdk-ios" "2.13.0"
github "awslabs/aws-mobile-appsync-sdk-ios" "b8aa2dde370168da1cf26fcf852d2360531f5267"
github "daltoniam/starscream" "3.0.6"
github "stephencelis/SQLite.swift" "0.12.2"
```

So this means carthage users installing awslabs/aws-mobile-appsync-sdk-ios get all the frameworks required, ie. taking a dependency on aws-amplify/aws-appsync-realtime-client-ios will pull in daltoniam/starscream

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
