### PR TITLE
Update travis xcode image 11.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift
-osx_image: xcode11
+osx_image: xcode11.3
 env:
   global:
   - FRAMEWORK_NAME=AWSAppSync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The AWS AppSync SDK for iOS enables you to access your AWS AppSync backend and perform operations like `Queries`, `Mutations` and `Subscriptions`. The SDK
 also includes support for offline operations.
 
+## 3.1.1
+
+### General SDK improvements
+- Build Carthage binaries using Xcode 11.3. See [PR #370](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/pull/370)
+
 ## 3.1.0
 
 ### General SDK improvements

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The AWS AppSync SDK for iOS enables you to access your AWS AppSync backend and p
 
 1. Now **Build** your project to start using the SDK. Whenever a new version of the SDK is released you can update by running `carthage update` and rebuilding your project to use the new features.
 
-    > Note: Currently, the AWSAppSync SDK for iOS builds the Carthage binaries using Xcode 10.1. To consume the pre-built binaries your Xcode version needs to be the same. Otherwise you will have to build the frameworks on your machine by passing `--no-use-binaries` flag to `carthage update` command.
+    > Note: Currently, the AWSAppSync SDK for iOS builds the Carthage binaries using Xcode 11.3. To consume the pre-built binaries your Xcode version needs to be the same. Otherwise you will have to build the frameworks on your machine by passing `--no-use-binaries` flag to `carthage update` command.
 
 1. In your source file, import the SDK using `import AWSAppSync`.
 


### PR DESCRIPTION
Updating Travis workflow to run with `xcode11.3`

https://docs.travis-ci.com/user/reference/osx/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
