### PR TITLE
Fix SwiftLint error

### DIFF
--- a/AWSAppSyncClient/AWSAppSyncCache.swift
+++ b/AWSAppSyncClient/AWSAppSyncCache.swift
@@ -139,7 +139,7 @@ public enum CacheType: String {
 
 /// Errors thrown trying to clear the client's caches
 public enum ClearCacheError: Error {
-    case failedToClear([CacheType:Error])
+    case failedToClear([CacheType: Error])
 }
 
 // MARK: - LocalizedError


### PR DESCRIPTION
It makes failing building for the following error: 
`Colon Violation: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. (colon)`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
