### PR TITLE
Fix bug in subscription where data is not translated correctly to a format valid for JSONSerialization

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		2171809123FDB28100E520C9 /* UserPoolsBasedConnectionPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2171808C23FDB28100E520C9 /* UserPoolsBasedConnectionPoolTests.swift */; };
 		2171809223FDB28100E520C9 /* OIDCBasedConnectionPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2171808D23FDB28100E520C9 /* OIDCBasedConnectionPoolTests.swift */; };
 		2171809323FDB28100E520C9 /* IAMBasedConnectionPoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2171808E23FDB28100E520C9 /* IAMBasedConnectionPoolTests.swift */; };
+		21933B3E24DA629B00F4D741 /* JSONValueSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21933B3D24DA629B00F4D741 /* JSONValueSerializationTests.swift */; };
 		21D38B90240B63FF00EC2A8D /* AWSAppSyncAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D38B8F240B63FF00EC2A8D /* AWSAppSyncAuthProvider.swift */; };
 		21D38B92240C099900EC2A8D /* AppSyncRealTimeClientOIDCAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D38B91240C099900EC2A8D /* AppSyncRealTimeClientOIDCAuthProvider.swift */; };
 		21D5286324169CEE005186BA /* IAMAuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D5286224169CEE005186BA /* IAMAuthInterceptor.swift */; };
@@ -494,6 +495,7 @@
 		2171808C23FDB28100E520C9 /* UserPoolsBasedConnectionPoolTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserPoolsBasedConnectionPoolTests.swift; sourceTree = "<group>"; };
 		2171808D23FDB28100E520C9 /* OIDCBasedConnectionPoolTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OIDCBasedConnectionPoolTests.swift; sourceTree = "<group>"; };
 		2171808E23FDB28100E520C9 /* IAMBasedConnectionPoolTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IAMBasedConnectionPoolTests.swift; sourceTree = "<group>"; };
+		21933B3D24DA629B00F4D741 /* JSONValueSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONValueSerializationTests.swift; sourceTree = "<group>"; };
 		21D38B8F240B63FF00EC2A8D /* AWSAppSyncAuthProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AWSAppSyncAuthProvider.swift; sourceTree = "<group>"; };
 		21D38B91240C099900EC2A8D /* AppSyncRealTimeClientOIDCAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncRealTimeClientOIDCAuthProvider.swift; sourceTree = "<group>"; };
 		21D5286224169CEE005186BA /* IAMAuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAMAuthInterceptor.swift; sourceTree = "<group>"; };
@@ -1085,6 +1087,7 @@
 				17E4F27C2282835A00E92474 /* SubscriptionMiscTests.swift */,
 				FAD17C6821C16E58008D116C /* SyncStrategyTests.swift */,
 				90DE0C48240A304D000E875B /* AWSAppSyncAuthTypeTests.swift */,
+				21933B3D24DA629B00F4D741 /* JSONValueSerializationTests.swift */,
 			);
 			path = AWSAppSyncUnitTests;
 			sourceTree = "<group>";
@@ -2050,6 +2053,7 @@
 				FAC28D3B221B0F09000F84CD /* CacheKeyTests.swift in Sources */,
 				2171809123FDB28100E520C9 /* UserPoolsBasedConnectionPoolTests.swift in Sources */,
 				90DE0C49240A304D000E875B /* AWSAppSyncAuthTypeTests.swift in Sources */,
+				21933B3E24DA629B00F4D741 /* JSONValueSerializationTests.swift in Sources */,
 				E47789592284B3DC008E7D6E /* MockAWSAppSyncServiceConfig.swift in Sources */,
 				FA4F0D9521D6ED9E0099D165 /* AppSyncClientComplexObjectMutationUnitTests.swift in Sources */,
 			);

--- a/AWSAppSyncClient/AWSAppSyncSubscriptionWatcher.swift
+++ b/AWSAppSyncClient/AWSAppSyncSubscriptionWatcher.swift
@@ -72,8 +72,10 @@ public final class AWSAppSyncSubscriptionWatcher<Subscription: GraphQLSubscripti
         }
 
         let requestString = type(of: subscription).requestString
+        // Transform variables into a map of each respective json values.
+        let variables = subscription.variables?.mapValues { $0?.jsonValue }
         subscriptionItem = connection.subscribe(requestString: requestString,
-                                                variables: subscription.variables) { [weak self] (event, item) in
+                                                variables: variables) { [weak self] (event, item) in
                                                     switch event {
                                                     case .connection(let value):
                                                         self?.handleConnectionEvent(value)

--- a/AWSAppSyncUnitTests/JSONValueSerializationTests.swift
+++ b/AWSAppSyncUnitTests/JSONValueSerializationTests.swift
@@ -1,0 +1,87 @@
+//
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Amazon Software License
+// http://aws.amazon.com/asl/
+//
+
+import XCTest
+import StarWarsAPI
+
+class JSONValueSerializationTests: XCTestCase {
+
+    /// Test to confirm that the variables containing Enum type is not valid JSONObject. The variables object should be
+    /// valid JSON for downstream serialization done by various consumers (ApolloClient, AppSyncRealTimeClient).
+    /// See https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/401 for more details.
+    ///
+    /// - Given: A code generated file containing the subscription `ReviewAddedSubscription` has variables containing a
+    /// single key-value pair. The type of the value is the `Episode` Enum.
+    /// - When:
+    ///    - Check if `variables` is a valid JSON object.
+    /// - Then:
+    ///    - `JSONSerialization.isValidJSONObject` returns false
+    ///
+    func test_subscriptionVariables_invalidJSONObject() {
+        let subscription = ReviewAddedSubscription(episode: .jedi)
+        guard let variables = subscription.variables else {
+            XCTFail("Failed to set up subscription operation containing variables")
+            return
+        }
+        XCTAssertFalse(JSONSerialization.isValidJSONObject(variables))
+    }
+
+    /// Test to confirm that variables containing Enum type, converted to JSONValue, can be serialized to Data.
+    /// See https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/401 for more details.
+    ///
+    /// - Given: A code generated file containing the subscription `ReviewAddedSubscription` has variables containing a
+    /// single key-value pair. The type of the value is the `Episode` Enum. Retrieve the `JSONValue` representation.
+    /// - When:
+    ///    - Serialize the JSON object to Data
+    /// - Then:
+    ///    - Successfully serialized JSON object
+    ///
+    func test_subscriptionVariablesJSONValue_ValidSerialization() throws {
+        let subscription = ReviewAddedSubscription(episode: .jedi)
+        guard let variables = subscription.variables else {
+            XCTFail("Failed to set up subscription operation containing variables")
+            return
+        }
+        let jsonValue = variables.mapValues { $0?.jsonValue }
+        XCTAssertTrue(JSONSerialization.isValidJSONObject(jsonValue))
+        let data = try? JSONSerialization.data(withJSONObject: jsonValue)
+        XCTAssertNotNil(data)
+    }
+
+    func test_variablesEnumAndStruct() throws {
+        let reviewInput = ReviewInput(stars: 1, favoriteColor: ColorInput(red: 1, green: 1, blue: 1))
+        guard let variables = CreateReviewForEpisodeMutation(episode: .jedi, review: reviewInput).variables else {
+            XCTFail("Could not get variables")
+            return
+        }
+        let jsonValue = variables.mapValues { $0?.jsonValue }
+        XCTAssertTrue(JSONSerialization.isValidJSONObject(jsonValue))
+        let data = try? JSONSerialization.data(withJSONObject: jsonValue)
+        XCTAssertNotNil(data)
+    }
+
+    func test_variablesMultipleBool() throws {
+        guard let variables = HeroNameConditionalBothQuery(skipName: true, includeName: false).variables else {
+            XCTFail("Could not get variables")
+            return
+        }
+        let jsonValue = variables.mapValues { $0?.jsonValue }
+        XCTAssertTrue(JSONSerialization.isValidJSONObject(jsonValue))
+        let data = try? JSONSerialization.data(withJSONObject: jsonValue)
+        XCTAssertNotNil(data)
+    }
+
+    func test_variablesGraphQLIDAndOptionalGraphQLID() throws {
+        guard let variables = HumanFriendsFilteredByIdQuery(id: "123", friendId: "234").variables else {
+            XCTFail("Could not get variables")
+            return
+        }
+        let jsonValue = variables.mapValues { $0?.jsonValue }
+        XCTAssertTrue(JSONSerialization.isValidJSONObject(jsonValue))
+        let data = try? JSONSerialization.data(withJSONObject: jsonValue)
+        XCTAssertNotNil(data)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
[Issue 401](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/401)

*Description of changes:*
See Issue for details

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
