### PR TITLE
chore: update changelog released 3.1.6 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ also includes support for offline operations.
 
 *Changes merged to `main`, but not yet released on a tag.*
 
+## 3.1.6
+
+### Misc. Updates
+
 - Upgrade to 2.16.0 SDK. [PR #410](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/pull/410)
 
 ## 3.1.5


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Missed the release version in changelog before triggering the AppSync release of 3.1.6, so unfortunately this commit comes after a tagged commit with 3.1.6

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
