### PR TITLE
fix: carthage script defaults to build only

### DIFF
--- a/build-support/carthage-build.sh
+++ b/build-support/carthage-build.sh
@@ -8,7 +8,7 @@
 ################################################################################
 
 # carthage-build.sh
-# Usage example: ./carthage-build.sh --platform iOS
+# Usage example: ./carthage-build.sh [build|archive]
 
 set -euo pipefail
 
@@ -36,4 +36,4 @@ echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x8
 echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
 
 export XCODE_XCCONFIG_FILE="$xcconfig"
-carthage build "$@"
+carthage "$@"


### PR DESCRIPTION
*Issue #, if available:*
There was an error during release of 3.1.7 that can be reproduced locally:
```
$ bash ./build-support/carthage-build.sh archive AWSAppSync

*** xcodebuild output can be found in /var/folders/wl/yhpbkfx93g38l3k0ts5f92_1kgt2sf/T/carthage-xcodebuild.54QdZf.log
Failed to read file or folder at /Users/[USER]/awslabs/aws-mobile-appsync-sdk-ios/Cartfile.resolved: Error Domain=NSCocoaErrorDomain Code=260 "The file “Cartfile.resolved” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/[USER]/awslabs/aws-mobile-appsync-sdk-ios/Cartfile.resolved, NSUnderlyingError=0x7fb2a4524cb0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
```

*Description of changes:*
It looked like the carthage workaround script has hardcoded `build`, and our release script ran 

```
bash ./build-support/carthage-build.sh archive $FRAMEWORK_NAME
```
so it was running
```
carthage build archive AWSAppSync
```

before having to introduce the carthage workaround script, we were doing `carthage archive AWSAppSync`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
