### PR TITLE
fix: remove inconsistent test in AppSyncSubscriptionWithSync

### DIFF
--- a/AWSAppSyncUnitTests/AppSyncSubscriptionWithSyncTests.swift
+++ b/AWSAppSyncUnitTests/AppSyncSubscriptionWithSyncTests.swift
@@ -203,29 +203,6 @@ class AppSyncSubscriptionWithSyncTests: XCTestCase {
         XCTAssertNotNil(result, "Should produce a non nil hash when all fields are present.")
     }
 
-    func testCancel() {
-        let expectation = XCTestExpectation(description: "Base Query Handler sync - should never be called")
-        expectation.isInverted = true
-        var toggle = true
-        let subscriptionWithSync = AppSyncSubscriptionWithSync(
-            appSyncClient: appsyncClient,
-            baseQuery: listPostsQuery,
-            deltaQuery: emptyQuery,
-            subscription: emptySubscription,
-            baseQueryHandler: { (result, error) in
-                if toggle { return }
-                expectation.fulfill()
-        },
-            deltaQueryHandler: emptyDeltaQueryHandler,
-            subscriptionResultHandler: emptySubscriptionResultHandler,
-            subscriptionMetadataCache: nil,
-            syncConfiguration: .init(baseRefreshIntervalInSeconds: 1),
-            handlerQueue: queue)
-        subscriptionWithSync.cancel()
-        toggle = false
-        wait(for: [expectation], timeout: 2.0)
-    }
-
     func testCancelWithBaseQueryAndDeinitNoStrongReferenceRetained() {
         var subscriptionWithSync: AppSyncSubscriptionWithSync? = AppSyncSubscriptionWithSync(
             appSyncClient: appsyncClient,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This test is inconsistent because `AppSyncSubscriptionWithSync` performs sync when it is initialized. Calling `cancel()` on it will be a race condition for whoever gets to the base query first or the check for cancelled first.

Related PR for cancel logic: https://github.com/awslabs/aws-mobile-appsync-sdk-ios/pull/355

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
