### PR TITLE
Update Framework Application Extension API Build Settings

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -2593,6 +2593,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = AD111EB21748A599F5796B74 /* Pods-AWSAppSync.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
@@ -2618,6 +2619,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C830ED8003E746C4C6799F8E /* Pods-AWSAppSync.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
* Update APPLICATION_EXTENSION_API_ONLY to YES to restrict API usage to those appropriate for an extension

*Issue #, if available:*

*Description of changes:*
Set APPLICATION_EXTENSION_API_ONLY build setting to YES for the framework target.  Including the framework in an extension, produces a `warning: linking against dylib not safe for use in application extensions` warning otherwise, but it doesn't look like the framework uses any API that would need the setting set to NO. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
