### PR TITLE
fix: lambda async auth provider

### DIFF
--- a/AWSAppSyncClient/Internal/AuthInterceptor/LambdaAuthInterceptor.swift
+++ b/AWSAppSyncClient/Internal/AuthInterceptor/LambdaAuthInterceptor.swift
@@ -74,6 +74,7 @@ class LambdaAuthInterceptor: AuthInterceptor {
         }
         var authToken: String?
         var authTokenError: Error?
+        let result: Swift.Result<String, Error>
         
         let semaphore = DispatchSemaphore(value: 0)
         
@@ -85,13 +86,14 @@ class LambdaAuthInterceptor: AuthInterceptor {
         semaphore.wait()
         
         if let authTokenError = authTokenError {
-            return .failure(authTokenError)
-        }
-        guard let authToken = authToken else {
+            result = .failure(authTokenError)
+        } else if let authToken = authToken {
+            result = .success(authToken)
+        } else {
             fatalError("Incompatible values for authorization token and error: nil, nil")
         }
         
-        return .success(authToken)
+        return result
     }
 }
 

--- a/AWSAppSyncClient/Internal/AuthInterceptor/LambdaAuthInterceptor.swift
+++ b/AWSAppSyncClient/Internal/AuthInterceptor/LambdaAuthInterceptor.swift
@@ -83,8 +83,12 @@ class LambdaAuthInterceptor: AuthInterceptor {
             semaphore.signal()
         }
         semaphore.wait()
-        guard let authToken = authToken, authTokenError == nil else {
-            return .failure(authTokenError!)
+        
+        if let authTokenError = authTokenError {
+            return .failure(authTokenError)
+        }
+        guard let authToken = authToken else {
+            fatalError("Incompatible values for authorization token and error: nil, nil")
         }
         
         return .success(authToken)

--- a/AWSAppSyncClient/Internal/AuthInterceptor/LambdaAuthInterceptor.swift
+++ b/AWSAppSyncClient/Internal/AuthInterceptor/LambdaAuthInterceptor.swift
@@ -19,7 +19,10 @@ class LambdaAuthInterceptor: AuthInterceptor {
 
     func interceptMessage(_ message: AppSyncMessage, for endpoint: URL) -> AppSyncMessage {
         let host = endpoint.host!
-        let authToken = authTokenProvider.getLatestAuthToken()
+        guard case let .success(authToken) = self.retrieveLatestAuthToken() else {
+            return message
+        }
+        
         guard case .subscribe = message.messageType else {
             return message
         }
@@ -41,7 +44,10 @@ class LambdaAuthInterceptor: AuthInterceptor {
         for endpoint: URL
     ) -> AppSyncConnectionRequest {
         let host = endpoint.host!
-        let authToken = authTokenProvider.getLatestAuthToken()
+        
+        guard case let .success(authToken) = self.retrieveLatestAuthToken() else {
+            return request
+        }
 
         let authHeader = TokenAuthHeader(token: authToken, host: host)
         let base64Auth = AppSyncJSONHelper.base64AuthenticationBlob(authHeader)
@@ -60,6 +66,28 @@ class LambdaAuthInterceptor: AuthInterceptor {
         }
         let signedRequest = AppSyncConnectionRequest(url: url)
         return signedRequest
+    }
+    
+    private func retrieveLatestAuthToken() -> Swift.Result<String, Error> {
+        guard let asyncAuthProvider = authTokenProvider as? AWSLambdaAuthProviderAsync else {
+            return .success(authTokenProvider.getLatestAuthToken())
+        }
+        var authToken: String?
+        var authTokenError: Error?
+        
+        let semaphore = DispatchSemaphore(value: 0)
+        
+        asyncAuthProvider.getLatestAuthToken { (token, error) in
+            authToken = token
+            authTokenError = error
+            semaphore.signal()
+        }
+        semaphore.wait()
+        guard let authToken = authToken, authTokenError == nil else {
+            return .failure(authTokenError!)
+        }
+        
+        return .success(authToken)
     }
 }
 

--- a/AWSAppSyncTestCommon/AppSyncClientTestHelper.swift
+++ b/AWSAppSyncTestCommon/AppSyncClientTestHelper.swift
@@ -48,7 +48,10 @@ public class AppSyncClientTestHelper: NSObject {
         case invalidAPIKey
         case invalidOIDC
         case invalidStaticCredentials
+        /// Sync Lambda auth provider
         case lambda
+        /// Async Lambda auth provider
+        case asyncLambda
         /// Delay set at 120 seconds
         case delayedInvalidOIDC
     }
@@ -238,6 +241,14 @@ public class AppSyncClientTestHelper: NSObject {
                 url: testConfiguration.lambdaEndpointURL,
                 serviceRegion: testConfiguration.lambdaEndpointRegion,
                 awsLambdaAuthProvider: MockLambdaAuthProvider(),
+                cacheConfiguration: cacheConfiguration,
+                s3ObjectManager: s3ObjectManager
+            )
+        case .asyncLambda:
+            appSyncConfig = try AWSAppSyncClientConfiguration(
+                url: testConfiguration.lambdaEndpointURL,
+                serviceRegion: testConfiguration.lambdaEndpointRegion,
+                awsLambdaAuthProvider: MockLambdaAuthAsyncProvider(),
                 cacheConfiguration: cacheConfiguration,
                 s3ObjectManager: s3ObjectManager
             )

--- a/AWSAppSyncTestCommon/MockAuthProviders.swift
+++ b/AWSAppSyncTestCommon/MockAuthProviders.swift
@@ -95,3 +95,15 @@ struct MockLambdaAuthProvider: AWSLambdaAuthProvider {
         return token
     }
 }
+
+struct MockLambdaAuthAsyncProvider: AWSLambdaAuthProviderAsync {
+    var token: String
+
+    init(with token: String = "custom-lambda-token") {
+        self.token = token
+    }
+    
+    func getLatestAuthToken(_ callback: @escaping (String?, Error?) -> Void) {
+        callback(token, nil)
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Fix `LambdaAuthInterceptor` to call either the sync or async provider (AWSLambdaAuthProviderAsync) to retrieve the authorization token.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
