### PR TITLE
fix: Update tests to avoid 'await' keyword

### DIFF
--- a/ApolloTests/ReadWriteFromStoreTests.swift
+++ b/ApolloTests/ReadWriteFromStoreTests.swift
@@ -15,7 +15,7 @@ class ReadWriteFromStoreTests: XCTestCase {
 
       let query = HeroNameQuery()
 
-      try await(store.withinReadTransaction { transaction in
+      try awaitWith(store.withinReadTransaction { transaction in
         let data = try transaction.read(query: query)
         
         XCTAssertEqual(data.hero?.__typename, "Droid")
@@ -35,7 +35,7 @@ class ReadWriteFromStoreTests: XCTestCase {
       
       let query = HeroNameQuery(episode: .jedi)
       
-      try await(store.withinReadWriteTransaction { transaction in
+      try awaitWith(store.withinReadWriteTransaction { transaction in
         try? transaction.update(query: query, { (data) in
             data.hero!.name = "asd"
         })
@@ -60,7 +60,7 @@ class ReadWriteFromStoreTests: XCTestCase {
       
       let query = HeroNameQuery()
       
-      try await(store.withinReadTransaction { transaction in
+      try awaitWith(store.withinReadTransaction { transaction in
         XCTAssertThrowsError(try transaction.read(query: query)) { error in
           if case let error as GraphQLResultError = error {
             XCTAssertEqual(error.path, ["hero", "name"])
@@ -85,7 +85,7 @@ class ReadWriteFromStoreTests: XCTestCase {
 
       let query = HeroNameQuery(episode: .jedi)
 
-      try await(store.withinReadWriteTransaction { transaction in
+      try awaitWith(store.withinReadWriteTransaction { transaction in
         
         try transaction.update(query: query) { (data) in
           data.hero?.name = "Artoo"
@@ -93,7 +93,7 @@ class ReadWriteFromStoreTests: XCTestCase {
         }
       })
 
-      let result = try await(store.load(query: query))
+      let result = try awaitWith(store.load(query: query))
 
       guard let data = result.data else { XCTFail(); return }
         
@@ -124,7 +124,7 @@ class ReadWriteFromStoreTests: XCTestCase {
     
       let query = HeroAndFriendsNamesQuery()
       
-      try await(store.withinReadTransaction { transaction in
+      try awaitWith(store.withinReadTransaction { transaction in
         let data = try transaction.read(query: query)
         
         XCTAssertEqual(data.hero?.name, "R2-D2")
@@ -156,13 +156,13 @@ class ReadWriteFromStoreTests: XCTestCase {
 
       let query = HeroAndFriendsNamesQuery()
 
-      try await(store.withinReadWriteTransaction { transaction in
+      try awaitWith(store.withinReadWriteTransaction { transaction in
         try transaction.update(query: query) { (data: inout HeroAndFriendsNamesQuery.Data) in
           data.hero?.friends?.append(.makeDroid(name: "C-3PO"))
         }
       })
       
-      let result = try await(store.load(query: query))
+      let result = try awaitWith(store.load(query: query))
       guard let data = result.data else { XCTFail(); return }
       
       XCTAssertEqual(data.hero?.name, "R2-D2")
@@ -179,7 +179,7 @@ class ReadWriteFromStoreTests: XCTestCase {
     try withCache(initialRecords: initialRecords) { (cache) in
       let store = ApolloStore(cache: cache)
       
-      try await(store.withinReadTransaction { transaction in
+      try awaitWith(store.withinReadTransaction { transaction in
         let r2d2 = try transaction.readObject(ofType: HeroDetails.self, withKey: "2001")
         
         XCTAssertEqual(r2d2.name, "R2-D2")
@@ -196,7 +196,7 @@ class ReadWriteFromStoreTests: XCTestCase {
     try withCache(initialRecords: initialRecords) { (cache) in
       let store = ApolloStore(cache: cache)
       
-      try await(store.withinReadTransaction { transaction in
+      try awaitWith(store.withinReadTransaction { transaction in
         XCTAssertNoThrow(try transaction.readObject(ofType: HeroDetails.self, withKey: "2001"))
       })
     }
@@ -222,7 +222,7 @@ class ReadWriteFromStoreTests: XCTestCase {
     try withCache(initialRecords: initialRecords) { (cache) in
       let store = ApolloStore(cache: cache)
 
-      try await(store.withinReadTransaction { transaction in
+      try awaitWith(store.withinReadTransaction { transaction in
         let friendsNamesFragment = try transaction.readObject(ofType: FriendsNames.self, withKey: "2001")
 
         let friendsNames = friendsNamesFragment.friends?.compactMap { $0?.name }
@@ -251,13 +251,13 @@ class ReadWriteFromStoreTests: XCTestCase {
     try withCache(initialRecords: initialRecords) { (cache) in
       let store = ApolloStore(cache: cache)
 
-      try await(store.withinReadWriteTransaction { transaction in
+      try awaitWith(store.withinReadWriteTransaction { transaction in
         try transaction.updateObject(ofType: FriendsNames.self, withKey: "2001") { (friendsNames: inout FriendsNames) in
           friendsNames.friends?.append(.makeDroid(name: "C-3PO"))
         }
       })
 
-      let result = try await(store.load(query: HeroAndFriendsNamesQuery()))
+      let result = try awaitWith(store.load(query: HeroAndFriendsNamesQuery()))
       guard let data = result.data else { XCTFail(); return }
 
       XCTAssertEqual(data.hero?.name, "R2-D2")

--- a/ApolloTests/WatchQueryTests.swift
+++ b/ApolloTests/WatchQueryTests.swift
@@ -296,7 +296,7 @@ class WatchQueryTests: XCTestCase {
       waitForExpectations(timeout: 5, handler: nil)
 
       let nameQuery = HeroNameQuery()
-      try await(store.withinReadWriteTransaction { transaction in
+      try awaitWith(store.withinReadWriteTransaction { transaction in
         try transaction.update(query: nameQuery) { (data: inout HeroNameQuery.Data) in
           data.hero?.name = "Artoo"
         }

--- a/ApolloTests/XCTestCase+Promise.swift
+++ b/ApolloTests/XCTestCase+Promise.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import AWSAppSync
 
 extension XCTestCase {
-  public func await<T>(_ promise: Promise<T>) throws -> T {
+  public func awaitWith<T>(_ promise: Promise<T>) throws -> T {
     let expectation = self.expectation(description: "Expected promise to be resolved")
     
     promise.finally {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The tests are not compiling with Xcode13. This replaces the 'await' method with 'awaitWith' method to avoid using the 'await' keyword

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
