### PR TITLE
fix: remove race condition on activeTimer access in AWSAppSyncHTTPNetworkTransport

### DIFF
--- a/AWSAppSyncClient.xcodeproj/project.pbxproj
+++ b/AWSAppSyncClient.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		21D38B92240C099900EC2A8D /* AppSyncRealTimeClientOIDCAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D38B91240C099900EC2A8D /* AppSyncRealTimeClientOIDCAuthProvider.swift */; };
 		21D5286324169CEE005186BA /* IAMAuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D5286224169CEE005186BA /* IAMAuthInterceptor.swift */; };
 		21D5286A2416A2B3005186BA /* IAMAuthInterceptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21D528692416A2B3005186BA /* IAMAuthInterceptorTests.swift */; };
+		21FF6A512745689A0065903E /* AWSAppSyncHTTPNetworkTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21FF6A502745689A0065903E /* AWSAppSyncHTTPNetworkTransportTests.swift */; };
 		3D9BF115227836800079F52F /* NetworkReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9BF114227836800079F52F /* NetworkReachability.swift */; };
 		70C68E4D132FE62623DB8C07 /* Pods_AWSAppSyncTestHostApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C707001F57B091A8A001CAB /* Pods_AWSAppSyncTestHostApp.framework */; };
 		7638897026A9E4D70061AF0B /* LambdaBasedConnectionPool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7638896F26A9E4D70061AF0B /* LambdaBasedConnectionPool.swift */; };
@@ -501,6 +502,7 @@
 		21D38B91240C099900EC2A8D /* AppSyncRealTimeClientOIDCAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSyncRealTimeClientOIDCAuthProvider.swift; sourceTree = "<group>"; };
 		21D5286224169CEE005186BA /* IAMAuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAMAuthInterceptor.swift; sourceTree = "<group>"; };
 		21D528692416A2B3005186BA /* IAMAuthInterceptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAMAuthInterceptorTests.swift; sourceTree = "<group>"; };
+		21FF6A502745689A0065903E /* AWSAppSyncHTTPNetworkTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSAppSyncHTTPNetworkTransportTests.swift; sourceTree = "<group>"; };
 		3D9BF114227836800079F52F /* NetworkReachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachability.swift; sourceTree = "<group>"; };
 		3EFDEC03028113885E64C3EF /* Pods-AWSAppSync-AWSAppSyncUnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AWSAppSync-AWSAppSyncUnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AWSAppSync-AWSAppSyncUnitTests/Pods-AWSAppSync-AWSAppSyncUnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		41C7F099AA45E55D08A8BA68 /* Pods-ApolloTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ApolloTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ApolloTests/Pods-ApolloTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1083,30 +1085,31 @@
 		FA8C62B221D6E3AA00FF9924 /* AWSAppSyncUnitTests */ = {
 			isa = PBXGroup;
 			children = (
-				B401C687260A8EEA00383820 /* Logging */,
-				B489D133235A6F54008DDAC9 /* Subscription */,
 				CCEF79DA21DE7CA6004AD64D /* AppSyncApolloCustomizationTests.swift */,
 				FAEC08E021CBE8B900A816DE /* AppSyncClientComplexObjectMutationUnitTests.swift */,
 				B48056BB22A992E200E4F742 /* AppSyncSubscriptionWithSyncTests.swift */,
+				90DE0C48240A304D000E875B /* AWSAppSyncAuthTypeTests.swift */,
 				FAC3E711220900A20037813E /* AWSAppSyncCacheConfigurationMigrationTests.swift */,
 				FAFB258822051D9600068B38 /* AWSAppSyncCacheConfigurationTests.swift */,
 				FA0C12C721CD96BF00B438CB /* AWSAppSyncClientConfigurationTests.swift */,
 				FABD70742205101600C99B47 /* AWSAppSyncClientInfoTests.swift */,
+				21FF6A502745689A0065903E /* AWSAppSyncHTTPNetworkTransportTests.swift */,
 				FA1A620B21E6533A00AA54D0 /* AWSAppSyncRetryHandlerTests.swift */,
 				FAF5D78A21D3EFA600FC04D2 /* AWSAppSyncServiceConfigTests.swift */,
 				FA6D0D86226782310034C7F6 /* AWSSQLiteNormalizedCacheTests.swift */,
 				FAC28D3A221B0F09000F84CD /* CacheKeyTests.swift */,
 				FAE1E0EE21D3DC9A005767C7 /* Foundation+UtilsTests.swift */,
 				FA8C62B521D6E3AA00FF9924 /* Info.plist */,
+				21933B3D24DA629B00F4D741 /* JSONValueSerializationTests.swift */,
+				B401C687260A8EEA00383820 /* Logging */,
 				E47789582284B3DC008E7D6E /* MockAWSAppSyncServiceConfig.swift */,
 				FA005959221222D800BFBD13 /* MutationOptimisticUpdateTests.swift */,
 				FA38636D21DD8FF200DBA2BC /* MutationQueueTests.swift */,
 				FA88834621E3D05800DEBCB3 /* ReachabilityChangeNotifierTests.swift */,
+				B489D133235A6F54008DDAC9 /* Subscription */,
 				FAD17C7021C2ABEA008D116C /* SubscriptionMessagesQueueTests.swift */,
 				17E4F27C2282835A00E92474 /* SubscriptionMiscTests.swift */,
 				FAD17C6821C16E58008D116C /* SyncStrategyTests.swift */,
-				90DE0C48240A304D000E875B /* AWSAppSyncAuthTypeTests.swift */,
-				21933B3D24DA629B00F4D741 /* JSONValueSerializationTests.swift */,
 			);
 			path = AWSAppSyncUnitTests;
 			sourceTree = "<group>";
@@ -2057,6 +2060,7 @@
 				FAFD409221D7039C0063D894 /* SubscriptionMessagesQueueTests.swift in Sources */,
 				CCEF79DB21DE7CA6004AD64D /* AppSyncApolloCustomizationTests.swift in Sources */,
 				FA88834721E3D05800DEBCB3 /* ReachabilityChangeNotifierTests.swift in Sources */,
+				21FF6A512745689A0065903E /* AWSAppSyncHTTPNetworkTransportTests.swift in Sources */,
 				2171809023FDB28100E520C9 /* SubscriptionConnectionFactoryTests.swift in Sources */,
 				FAE7948721D6EB290032D37F /* AWSAppSyncClientConfigurationTests.swift in Sources */,
 				FAC3E712220900A20037813E /* AWSAppSyncCacheConfigurationMigrationTests.swift in Sources */,

--- a/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
+++ b/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import AWSCore
-import AppSyncRealTimeClient
 
 public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
     public enum AppSyncAuthProvider {

--- a/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
+++ b/AWSAppSyncClient/AWSAppSyncHTTPNetworkTransport.swift
@@ -31,6 +31,8 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
         }
     }
 
+    // MARK: - Stored Properties -
+
     private let url: URL
     private let session: URLSession
     private let serializationFormat = JSONSerializationFormat.self
@@ -38,8 +40,10 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
     private let sendOperationIdentifiers: Bool
     private var retryStrategy: AWSAppSyncRetryStrategy
     
-    private let activeTimersQueue = DispatchQueue(label: "AWSAppSyncHTTPNetworkTransport.activeTimers", attributes: .concurrent)
+    private let activeTimersQueue = DispatchQueue(label: "AWSAppSyncHTTPNetworkTransport.activeTimers")
     private var activeTimers: [String: DispatchSourceTimer] = [:]
+
+    // MARK: - Initializers -
 
     /// Designated initializer. Creates a network transport with the specified server
     /// URL, URLSession (which must be created with an appropriate delegate and queue
@@ -181,6 +185,8 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
         )
     }
 
+    // MARK: - Internal Functions -
+
     func initRequest(request: inout URLRequest) {
         request.httpMethod = "POST"
         request.setValue(NSDate().aws_stringValue(AWSDateISO8601DateFormat2), forHTTPHeaderField: "X-Amz-Date")
@@ -250,13 +256,9 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
                                                          retryHandler: retryHandler,
                                                          networkTransportOperation: networkTransportOperation,
                                                          completionHandler: completionHandler)
-                                self?.activeTimersQueue.async(flags: .barrier) {
-                                    self?.activeTimers.removeValue(forKey: taskUUID)
-                                }
+                                self?.removeActiveTimer(taskUUID: taskUUID)
                             }
-                            self?.activeTimersQueue.async(flags: .barrier) {
-                                self?.activeTimers[taskUUID] = timer
-                            }
+                            self?.addActiveTimer(taskUUID: taskUUID, timer: timer)
                         } else {
                             completionHandler(nil, error)
                         }
@@ -515,6 +517,28 @@ public class AWSAppSyncHTTPNetworkTransport: AWSNetworkTransport {
         }
         return ["query": type(of: operation).requestString, "variables": operationVariables]
     }
+
+    // MARK: - Protected State Transitions -
+
+    private func removeActiveTimer(taskUUID: String) {
+        if #available(iOS 10.0, *) {
+            dispatchPrecondition(condition: .notOnQueue(activeTimersQueue))
+        }
+        activeTimersQueue.sync {
+            _ = activeTimers.removeValue(forKey: taskUUID)
+        }
+    }
+
+    private func addActiveTimer( taskUUID: String, timer: DispatchSourceTimer?) {
+        if #available(iOS 10.0, *) {
+            dispatchPrecondition(condition: .notOnQueue(activeTimersQueue))
+        }
+        activeTimersQueue.sync {
+            activeTimers[taskUUID] = timer
+        }
+    }
+
+    // MARK: - Internal Class -
 
     internal class AWSAppSyncHTTPNetworkTransportOperation: Cancellable {
 

--- a/AWSAppSyncUnitTests/AWSAppSyncHTTPNetworkTransportTests.swift
+++ b/AWSAppSyncUnitTests/AWSAppSyncHTTPNetworkTransportTests.swift
@@ -180,7 +180,7 @@ class AWSAppSyncHTTPNetworkTransportTests: XCTestCase {
         var currentAttempt = 0
         MockURLProtocol.requestHandler = { request in
             currentAttempt += 1
-            if currentAttempt < 10000 {
+            if currentAttempt < 100 {
                 // Mock a response with "Retry-After" header to perform a retry with 0 interval (immediately retry)
                 let headers = ["Retry-After": "0"]
                 let response = HTTPURLResponse(url: self.url, statusCode: 200, httpVersion: nil, headerFields: headers)!

--- a/AWSAppSyncUnitTests/AWSAppSyncHTTPNetworkTransportTests.swift
+++ b/AWSAppSyncUnitTests/AWSAppSyncHTTPNetworkTransportTests.swift
@@ -1,0 +1,221 @@
+//
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Licensed under the Amazon Software License
+// http://aws.amazon.com/asl/
+//
+
+import XCTest
+@testable import AWSAppSyncTestCommon
+@testable import AWSAppSync
+
+class MockURLProtocol: URLProtocol {
+    
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+    
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+    
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))?
+    
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            fatalError("Handler is unavailable.")
+        }
+        
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data = data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+    
+    override func stopLoading() {
+    }
+}
+
+class AWSAppSyncHTTPNetworkTransportTests: XCTestCase {
+    
+    let url = URL(string: "http://www.amazon.com/for_unit_testing")!
+    let authProvider = AWSAppSyncHTTPNetworkTransport.AppSyncAuthProvider
+        .apiKey(BasicAWSAPIKeyAuthProvider(key: "key"))
+    let data = "{\"data\": \"data\"}".data(using: .utf8)
+    
+    func testSendNetworkRequestSuccess() throws {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: self.url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, self.data)
+        }
+        
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let urlSession = URLSession.init(configuration: configuration)
+        let transport = AWSAppSyncHTTPNetworkTransport(url: url,
+                                                       urlSession: urlSession,
+                                                       authProvider: authProvider,
+                                                       sendOperationIdentifiers: false,
+                                                       retryStrategy: .exponential)
+        
+        let urlRequest = URLRequest(url: url)
+        
+        let sendRequestSuccess = expectation(description: "send request successful")
+        _ = transport.sendNetworkRequest(request: urlRequest) { result in
+            switch result {
+            case .success(let response):
+                print(response)
+                sendRequestSuccess.fulfill()
+            case .failure(let error):
+                XCTFail("\(error.localizedDescription)")
+            }
+        }
+        wait(for: [sendRequestSuccess], timeout: 1)
+    }
+    
+    func testSendNetworkRequestSuccessFailure() {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: self.url, statusCode: 400, httpVersion: nil, headerFields: nil)!
+            return (response, self.data)
+        }
+        
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let urlSession = URLSession.init(configuration: configuration)
+        let transport = AWSAppSyncHTTPNetworkTransport(url: url,
+                                                       urlSession: urlSession,
+                                                       authProvider: authProvider,
+                                                       sendOperationIdentifiers: false,
+                                                       retryStrategy: .exponential)
+        
+        let urlRequest = URLRequest(url: url)
+        
+        let sendRequestFailed = expectation(description: "send request failed")
+        _ = transport.sendNetworkRequest(request: urlRequest) { result in
+            switch result {
+            case .success(let response):
+                XCTFail("Should have failed, instead got: \(response)")
+            case .failure(let error):
+                print("\(error.localizedDescription)")
+                sendRequestFailed.fulfill()
+                
+            }
+        }
+        wait(for: [sendRequestFailed], timeout: 1)
+    }
+    
+    func testSendGraphQLRequestSuccess() {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: self.url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, self.data)
+        }
+        
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let urlSession = URLSession.init(configuration: configuration)
+        let transport = AWSAppSyncHTTPNetworkTransport(url: url,
+                                                       urlSession: urlSession,
+                                                       authProvider: authProvider,
+                                                       sendOperationIdentifiers: false,
+                                                       retryStrategy: .exponential)
+        let sendGraphQLRequestSuccess = expectation(description: "send graphql request successful")
+        let request = NSMutableURLRequest(url: url)
+        let retryHandler = AWSAppSyncRetryHandler(retryStrategy: .exponential)
+        let transportOperation = AWSAppSyncHTTPNetworkTransport.AWSAppSyncHTTPNetworkTransportOperation()
+        transport.sendGraphQLRequest(mutableRequest: request,
+                                     retryHandler: retryHandler,
+                                     networkTransportOperation: transportOperation) { result, error in
+            if let error = error {
+                XCTFail("Should not get error: \(error)")
+            } else if let result = result {
+                print(result)
+                sendGraphQLRequestSuccess.fulfill()
+            } else {
+                XCTFail("Missing completion result")
+            }
+        }
+        wait(for: [sendGraphQLRequestSuccess], timeout: 1)
+    }
+    
+    func testSendGraphQLRequestFailure() {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: self.url, statusCode: 400, httpVersion: nil, headerFields: nil)!
+            return (response, self.data)
+        }
+        
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let urlSession = URLSession.init(configuration: configuration)
+        
+        let transport = AWSAppSyncHTTPNetworkTransport(url: url,
+                                                       urlSession: urlSession,
+                                                       authProvider: authProvider,
+                                                       sendOperationIdentifiers: false,
+                                                       retryStrategy: .exponential)
+        let sendGraphQLRequestFailure = expectation(description: "send graphql request failure")
+        let request = NSMutableURLRequest(url: url)
+        let retryHandler = AWSAppSyncRetryHandler(retryStrategy: .exponential)
+        let transportOperation = AWSAppSyncHTTPNetworkTransport.AWSAppSyncHTTPNetworkTransportOperation()
+        transport.sendGraphQLRequest(mutableRequest: request,
+                                     retryHandler: retryHandler,
+                                     networkTransportOperation: transportOperation) { result, error in
+            if error != nil {
+                sendGraphQLRequestFailure.fulfill()
+            } else if let result = result {
+                XCTFail("Should have error, instead got: \(result)")
+            } else {
+                XCTFail("Missing completion result")
+            }
+        }
+        wait(for: [sendGraphQLRequestFailure], timeout: 1)
+    }
+    
+    
+    func testSendGraphQLRequestFailureWithRetry() {
+        var currentAttempt = 0
+        MockURLProtocol.requestHandler = { request in
+            currentAttempt += 1
+            if currentAttempt < 10000 {
+                // Mock a response with "Retry-After" header to perform a retry with 0 interval (immediately retry)
+                let headers = ["Retry-After": "0"]
+                let response = HTTPURLResponse(url: self.url, statusCode: 200, httpVersion: nil, headerFields: headers)!
+                return (response, Data())
+            } else {
+                let response = HTTPURLResponse(url: self.url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (response, Data())
+            }
+        }
+        
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let urlSession = URLSession.init(configuration: configuration)
+    
+        let transport = AWSAppSyncHTTPNetworkTransport(url: url,
+                                                       urlSession: urlSession,
+                                                       authProvider: authProvider,
+                                                       sendOperationIdentifiers: false,
+                                                       retryStrategy: .exponential)
+        
+        let sendGraphQLRequestFailure = expectation(description: "send graphql request failure")
+        let request = NSMutableURLRequest(url: url)
+        let retryHandler = AWSAppSyncRetryHandler(retryStrategy: .exponential)
+        let transportOperation = AWSAppSyncHTTPNetworkTransport.AWSAppSyncHTTPNetworkTransportOperation()
+        transport.sendGraphQLRequest(mutableRequest: request,
+                                     retryHandler: retryHandler,
+                                     networkTransportOperation: transportOperation) { result, error in
+            if error != nil {
+                sendGraphQLRequestFailure.fulfill()
+            } else if let result = result {
+                XCTFail("Should have error, instead got: \(result)")
+            } else {
+                XCTFail("Missing completion result")
+            }
+        }
+        wait(for: [sendGraphQLRequestFailure], timeout: 10)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/487

*Description of changes:*
`activeTimers` is of type `[String: DispatchSourceTimer]` so accessing this does not appear to be thread safe in the code. `sendGraphQLRequest` under certain conditions will retry like when service returns 5xx (or other retry scenarios). It will create a new timer, set it on `activeTimers`, while other timers that were created already may fire and remove it's timer from `activeTimers`. A race condition could happen if T1 calls sendGraphQLRequest due to a previous timer firing, fails the request, completes on T2 and retry logic decides to create another timer which accesses `activeTimers`. T1 continues to the next line from `sendGraphQLRequest` and removes a timer, which happens at the same time T2 is setting the new timer.

This PR adds the access to `activeTimers` under a [Dispatch Barrier](https://developer.apple.com/documentation/dispatch/dispatch_barrier) to ensure that each block of execution done serially
- [x] Ran unit and integration tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
