### PR TITLE
chore: skip build xcframework when build for cocoapods

### DIFF
--- a/build-support/build-xcframeworks.sh
+++ b/build-support/build-xcframeworks.sh
@@ -5,6 +5,13 @@ pwd=$(pwd)
 ios_device_archive_path="$pwd/build/iOS/AWSAppSync"
 ios_simulator_archive_path="$pwd/build/Simulator/AWSAppSync"
 xcframework_path="$pwd/build/$framework.xcframework"
+
+if [ -d "$xcframework_path" ]
+then
+  echo "XCFramework exists already, skipping."
+  exit 0
+fi
+
 # archive for device
 xcodebuild archive -workspace AWSAppSyncClient.xcworkspace \
 					-scheme $framework \


### PR DESCRIPTION
*Description of changes:*
`before_deploy` Travis-CI step gets called once for each `deploy_provider` so to prevent build failures (and speed up the build process) when building for cocoapods, this PR introduces a change to skip the XCFramework build if the destination folder already exists.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
