### PR TITLE
fix: Repopulate records table with empty QUERY_ROOT after caches are cleared

### DIFF
--- a/AWSAppSyncClient/AWSAppSyncClientConfiguration.swift
+++ b/AWSAppSyncClient/AWSAppSyncClientConfiguration.swift
@@ -587,13 +587,7 @@ public class AWSAppSyncClientConfiguration {
         if let databaseURL = databaseURL, let cache = try? AWSSQLiteNormalizedCache(fileURL: databaseURL) {
             store = ApolloStore(cache: cache)
         } else {
-            // Prepopulate the InMemoryNormalizedCache record set with an empty QUERY_ROOT, to allow optimistic
-            // updates against empty caches to succeed. Otherwise, such an operation will fail with a "missingValue"
-            // error (#92)
-            let emptyQueryRootRecord = Record(key: AWSAppSyncClient.EmptyQuery.rootCacheKey, [:])
-            let records = RecordSet(records: [emptyQueryRootRecord])
-            let inMemoryCache = InMemoryNormalizedCache(records: records)
-            store = ApolloStore(cache: inMemoryCache)
+            store = ApolloStore(cache: InMemoryNormalizedCache())
         }
         return store
     }

--- a/AWSAppSyncClient/Apollo/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/AWSAppSyncClient/Apollo/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -2,7 +2,16 @@ public final class InMemoryNormalizedCache: NormalizedCache {
   private var records: RecordSet
 
   public init(records: RecordSet = RecordSet()) {
-    self.records = records
+    if records.isEmpty {
+      // Prepopulate the InMemoryNormalizedCache record set with an empty QUERY_ROOT, to allow optimistic
+      // updates against empty caches to succeed. Otherwise, such an operation will fail with a "missingValue"
+      // error (#92)
+      let emptyQueryRootRecord = Record(key: AWSAppSyncClient.EmptyQuery.rootCacheKey, [:])
+      self.records = RecordSet(records: [emptyQueryRootRecord])
+    }
+    else {
+      self.records = records
+    }
   }
 
   public func loadRecords(forKeys keys: [CacheKey]) -> Promise<[Record?]> {
@@ -16,6 +25,13 @@ public final class InMemoryNormalizedCache: NormalizedCache {
 
   public func clear() -> Promise<Void> {
     records.clear()
+
+    // Prepopulate the InMemoryNormalizedCache record set with an empty QUERY_ROOT, to allow optimistic
+    // updates against empty caches to succeed. Otherwise, such an operation will fail with a "missingValue"
+    // error (#92)
+    let emptyQueryRootRecord = Record(key: AWSAppSyncClient.EmptyQuery.rootCacheKey, [:])
+    self.records = RecordSet(records: [emptyQueryRootRecord])
+
     return Promise(fulfilled: ())
   }
 }

--- a/AWSAppSyncClient/Apollo/Sources/Apollo/InMemoryNormalizedCache.swift
+++ b/AWSAppSyncClient/Apollo/Sources/Apollo/InMemoryNormalizedCache.swift
@@ -1,37 +1,34 @@
 public final class InMemoryNormalizedCache: NormalizedCache {
-  private var records: RecordSet
-
-  public init(records: RecordSet = RecordSet()) {
-    if records.isEmpty {
-      // Prepopulate the InMemoryNormalizedCache record set with an empty QUERY_ROOT, to allow optimistic
-      // updates against empty caches to succeed. Otherwise, such an operation will fail with a "missingValue"
-      // error (#92)
-      let emptyQueryRootRecord = Record(key: AWSAppSyncClient.EmptyQuery.rootCacheKey, [:])
-      self.records = RecordSet(records: [emptyQueryRootRecord])
+    private var records: RecordSet
+    
+    public init(records: RecordSet = RecordSet()) {
+        if records.isEmpty {
+            self.records = InMemoryNormalizedCache.emptyQueryRootRecords()
+        } else {
+            self.records = records
+        }
     }
-    else {
-      self.records = records
+    
+    public func loadRecords(forKeys keys: [CacheKey]) -> Promise<[Record?]> {
+        let records = keys.map { self.records[$0] }
+        return Promise(fulfilled: records)
     }
-  }
-
-  public func loadRecords(forKeys keys: [CacheKey]) -> Promise<[Record?]> {
-    let records = keys.map { self.records[$0] }
-    return Promise(fulfilled: records)
-  }
-
-  public func merge(records: RecordSet) -> Promise<Set<CacheKey>> {
-    return Promise(fulfilled: self.records.merge(records: records))
-  }
-
-  public func clear() -> Promise<Void> {
-    records.clear()
-
-    // Prepopulate the InMemoryNormalizedCache record set with an empty QUERY_ROOT, to allow optimistic
-    // updates against empty caches to succeed. Otherwise, such an operation will fail with a "missingValue"
-    // error (#92)
-    let emptyQueryRootRecord = Record(key: AWSAppSyncClient.EmptyQuery.rootCacheKey, [:])
-    self.records = RecordSet(records: [emptyQueryRootRecord])
-
-    return Promise(fulfilled: ())
-  }
+    
+    public func merge(records: RecordSet) -> Promise<Set<CacheKey>> {
+        return Promise(fulfilled: self.records.merge(records: records))
+    }
+    
+    public func clear() -> Promise<Void> {
+        records.clear()
+        self.records = InMemoryNormalizedCache.emptyQueryRootRecords()
+        return Promise(fulfilled: ())
+    }
+    
+    private static func emptyQueryRootRecords() -> RecordSet {
+        // Prepopulate the InMemoryNormalizedCache record set with an empty QUERY_ROOT, to allow optimistic
+        // updates against empty caches to succeed. Otherwise, such an operation will fail with a "missingValue"
+        // error (#92)
+        let emptyQueryRootRecord = Record(key: AWSAppSyncClient.EmptyQuery.rootCacheKey, [:])
+        return RecordSet(records: [emptyQueryRootRecord])
+    }
 }

--- a/AWSAppSyncClient/Internal/AWSSQLiteNormalizedCache.swift
+++ b/AWSAppSyncClient/Internal/AWSSQLiteNormalizedCache.swift
@@ -54,13 +54,7 @@ final class AWSSQLiteNormalizedCache: NormalizedCache {
     func clear() -> Promise<Void> {
         return Promise {
             try db.run(self.records.delete())
-            // Prepopulate the cache with an empty QUERY_ROOT, to allow optimistic updates of query results that have
-            // not yet been retrieved from the service. This works around Apollo's behavior of throwing an error if
-            // readObject find no records. (#92)
-            try db.run(self.records.insert(
-                key <- AWSSQLiteNormalizedCache.queryRootKey,
-                record <- "{}"
-            ))
+            try insertEmptyQueryRoot()
         }
     }
 
@@ -77,14 +71,18 @@ final class AWSSQLiteNormalizedCache: NormalizedCache {
         let queryRootRecords = records.filter(key == AWSSQLiteNormalizedCache.queryRootKey)
         let recordCount = try db.scalar(queryRootRecords.count)
         if recordCount == 0 {
-            // Prepopulate the cache with an empty QUERY_ROOT, to allow optimistic updates of query results that have
-            // not yet been retrieved from the service. This works around Apollo's behavior of throwing an error if
-            // readObject find no records. (#92)
-            try db.run(records.insert(
-                key <- AWSSQLiteNormalizedCache.queryRootKey,
-                record <- "{}"
-            ))
+            try insertEmptyQueryRoot()
         }
+    }
+    
+    private func insertEmptyQueryRoot() throws {
+        // Prepopulate the cache with an empty QUERY_ROOT, to allow optimistic updates of query results that have
+        // not yet been retrieved from the service. This works around Apollo's behavior of throwing an error if
+        // readObject find no records. (#92)
+        try db.run(self.records.insert(
+            key <- AWSSQLiteNormalizedCache.queryRootKey,
+            record <- "{}"
+        ))
     }
 
     /// Decompose a cache key into path components to derive a list of keys that *might* be record

--- a/AWSAppSyncClient/Internal/AWSSQLiteNormalizedCache.swift
+++ b/AWSAppSyncClient/Internal/AWSSQLiteNormalizedCache.swift
@@ -54,6 +54,13 @@ final class AWSSQLiteNormalizedCache: NormalizedCache {
     func clear() -> Promise<Void> {
         return Promise {
             try db.run(self.records.delete())
+            // Prepopulate the cache with an empty QUERY_ROOT, to allow optimistic updates of query results that have
+            // not yet been retrieved from the service. This works around Apollo's behavior of throwing an error if
+            // readObject find no records. (#92)
+            try db.run(self.records.insert(
+                key <- AWSSQLiteNormalizedCache.queryRootKey,
+                record <- "{}"
+            ))
         }
     }
 

--- a/AWSAppSyncUnitTests/MutationOptimisticUpdateTests.swift
+++ b/AWSAppSyncUnitTests/MutationOptimisticUpdateTests.swift
@@ -37,11 +37,19 @@ class MutationOptimisticUpdateTests: XCTestCase {
     }
 
     func testMutation_WithOptimisticUpdate_UpdatesEmptyPersistentCache() throws {
-        try doMutationWithOptimisticUpdate(usingBackingDatabase: true)
+        try doMutationWithOptimisticUpdate(usingBackingDatabase: true, afterClearingCaches: false)
     }
 
     func testMutation_WithOptimisticUpdate_UpdatesEmptyInMemoryCache() throws {
-        try doMutationWithOptimisticUpdate(usingBackingDatabase: false)
+        try doMutationWithOptimisticUpdate(usingBackingDatabase: false, afterClearingCaches: false)
+    }
+
+    func testMutation_WithOptimisticUpdate_UpdatesEmptyPersistentCacheAfterClearingCaches() throws {
+        try doMutationWithOptimisticUpdate(usingBackingDatabase: true, afterClearingCaches: true)
+    }
+
+    func testMutation_WithOptimisticUpdate_UpdatesEmptyInMemoryCacheAfterClearingCaches() throws {
+        try doMutationWithOptimisticUpdate(usingBackingDatabase: false, afterClearingCaches: true)
     }
 
     func testMutation_WithoutOptimisticUpdate_DoesNotUpdateEmptyCache() throws {
@@ -203,7 +211,8 @@ class MutationOptimisticUpdateTests: XCTestCase {
 
     // MARK - Utility methods
 
-    func doMutationWithOptimisticUpdate(usingBackingDatabase: Bool) throws {
+    func doMutationWithOptimisticUpdate(usingBackingDatabase: Bool,
+                                        afterClearingCaches: Bool) throws {
         let addPost = DefaultTestPostData.defaultCreatePostWithoutFileUsingParametersMutation
 
         // We will set up a response block that never actually invokes the completion handler. This allows us to
@@ -222,6 +231,10 @@ class MutationOptimisticUpdateTests: XCTestCase {
             : nil
 
         let appSyncClient = try UnitTestHelpers.makeAppSyncClient(using: mockHTTPTransport, cacheConfiguration: resolvedCacheConfiguration)
+
+        if afterClearingCaches {
+            try appSyncClient.clearCaches()
+        }
 
         let newPost = ListPostsQuery.Data.ListPost(
             id: "TEMPORARY-\(UUID().uuidString)",


### PR DESCRIPTION
*Issue #, if available:*
#92 (kinda?)

*Description of changes:*
As part of working around an issue allowing optimistic updates of query results that haven't been retrieved from the service, @palpatim introduced code to pre-populate an empty table with an empty QUERY_ROOT, resolving the issue. However the issue resurfaces if at any point the caches are cleared, as the table is not then repopulated with the empty QUERY_ROOT.

So if, for example, a user installs an app for the first time and log into an account backed by AWS App Sync, the existing workaround correctly ensures that optimistic updates don't fail when the underlying query results have not been fetched from the service, but if that user were to sign out (causing the caches to be cleared) and then into another account, the workaround is no longer in place, and optimistic updates will fail.

This PR introduces changes to repopulate the cache with the empty QUERY_ROOT immediately after clearing it, thereby ensuring that optimistic updates do not fail after calling `clearCaches()`. The requisite tests have also been updated to showcase the issue, and show that it is resolved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
