### PR TITLE
fix: deserialization of custom scalars

### DIFF
--- a/AWSAppSyncClient/AWSAppSyncCache.swift
+++ b/AWSAppSyncClient/AWSAppSyncCache.swift
@@ -10,6 +10,8 @@ import Foundation
 public enum AWSAppSyncQueriesCacheError: Error {
     case invalidRecordEncoding(record: String)
     case invalidRecordShape(object: Any)
+    @available(*, deprecated, message: "No longer being used and will be removed in a future revision.")
+    case invalidRecordValue(value: Any)
 }
 
 /// Errors thrown during creation or migration of AppSync caches

--- a/AWSAppSyncClient/AWSAppSyncCache.swift
+++ b/AWSAppSyncClient/AWSAppSyncCache.swift
@@ -10,7 +10,6 @@ import Foundation
 public enum AWSAppSyncQueriesCacheError: Error {
     case invalidRecordEncoding(record: String)
     case invalidRecordShape(object: Any)
-    case invalidRecordValue(value: Any)
 }
 
 /// Errors thrown during creation or migration of AppSync caches

--- a/AWSAppSyncClient/Internal/SQLiteSerialization.swift
+++ b/AWSAppSyncClient/Internal/SQLiteSerialization.swift
@@ -45,7 +45,7 @@ final class SQLiteSerialization {
         switch fieldJSONValue {
         case let dictionary as JSONObject:
             guard let reference = dictionary[serializedReferenceKey] as? String else {
-                throw AWSAppSyncQueriesCacheError.invalidRecordValue(value: fieldJSONValue)
+                return fieldJSONValue
             }
             return Reference(key: reference)
         case let array as [JSONValue]:


### PR DESCRIPTION
*Issue #, if available:*
None.

*Description of changes:*
We use a number of custom scalars with AWS AppSync in our codebase, which are successfully parsed from the AppSync service, and get stored within the SQLite cache, but fail to be deserialised and thus cause cache reads involving these types to completely fail. This has primarily meant that we are unable to cache these calls at all, relying on live data for calls relying on our custom scalar types.

This is exactly the same as [an issue raised on the Apollo library in 2018](https://github.com/apollographql/apollo-ios/issues/329), and was resolved by returning the `fieldJSONValue` from the `SQLiteSerialization.deserialize(fieldJSONValue:)`, which correctly returns the custom scalar value as-is ([in this PR](https://github.com/apollographql/apollo-ios/pull/1144)).

I've replicated the changes here, including the removal of the then defunct `AWSAppSyncQueriesCacheError.invalidRecordValue` case. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
