### PR TITLE
Update AWSAppSync.podspec

### DIFF
--- a/AWSAppSync.podspec
+++ b/AWSAppSync.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.swift_version = '5.5.2'
 
-  s.dependency 'AWSCore', '~> 2.28.0'
+  s.dependency 'AWSCore', '~> 2.29.0'
   s.dependency 'SQLite.swift', '~> 0.12.2'
   s.dependency 'ReachabilitySwift', '5.0.0'
   s.dependency 'AppSyncRealTimeClient', '~> 1.7'

--- a/AWSAppSync.podspec
+++ b/AWSAppSync.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.swift_version = '5.5.2'
 
-  s.dependency 'AWSCore', '~> 2.27.0'
+  s.dependency 'AWSCore', '~> 2.28.0'
   s.dependency 'SQLite.swift', '~> 0.12.2'
   s.dependency 'ReachabilitySwift', '5.0.0'
   s.dependency 'AppSyncRealTimeClient', '~> 1.7'


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/549

*Description of changes:*
That issue and the attached PR is about SPM.
This PR does exactly the same but for Cocoapods.

So, we can now update other dependecies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
