### PR TITLE
chore: Update CODEOWNERS [skip ci]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*        @awslabs/amplify-data
+*        @awslabs/amplify-ios


### PR DESCRIPTION
Reverts awslabs/aws-mobile-appsync-sdk-ios#540