### PR TITLE
fix: podspec AppSyncRTClient version to ~> 3.0

### DIFF
--- a/AWSAppSync.podspec
+++ b/AWSAppSync.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'AWSCore', '~> 2.34.0'
   s.dependency 'SQLite.swift', '~> 0.12.2'
-  s.dependency 'AppSyncRealTimeClient', '~> 3'
+  s.dependency 'AppSyncRealTimeClient', '~> 3.0'
 
   s.source_files = 'AWSAppSyncClient/AWSAppSync.h', 'AWSAppSyncClient/*.swift', 'AWSAppSyncClient/Internal/**/*.{h,m,swift}', 'AWSAppSyncClient/Apollo/Sources/Apollo/*.swift'
   s.public_header_files = ['AWSAppSyncClient/AWSAppSync.h', 'AWSAppSyncClient/AWSAppSync-Swift.h', 'AWSAppSyncClient/Internal/AppSyncLogHelper.h']


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The podspec or the Package.swift file is used by the developer to resolve the versions with their respective package manager. Our dependency on AppSyncRealTimeClient should have the same version rule so we have to make sure the two results in the same min and maximum versions when taking on the AppSync SDK dependency.

SPM [Package.swift](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/blob/main/Package.swift#L22) 
```
.package(
      name: "AppSyncRealTimeClient",
      url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
      from: "3.0.0"
  ),
```
According to [SPM docs](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#package-dependency), it will select a version like `3.0.0`, `3.1.2`, or `3.9.0`, but not `4.0.0`.

The corresponding podspec version should be `~> 3.0` ([SO ref](https://stackoverflow.com/questions/20213751/what-is-the-usage-of-in-cocoapods)), this will get a version up to 4.0.0 (but not including 4.0.0 and higher), so same minimum`3.0.0`, `3.1.2`, `3.9.0`, but not `4.0.0`.

Currently `~> 3` will get a version of 3 and higher (same as if it was omitted), including 4.0.0.

AppSyncRealTimeClient's current version is 3.1.2 (https://github.com/aws-amplify/aws-appsync-realtime-client-ios/releases/tag/3.1.2) so there isn't an impact but if it were to release a `4.0.0`, then it will pull in the breaking changes when resolving the pod dependencies.

Another example is Amplify V1
[Amplify V1 SPM](https://github.com/aws-amplify/amplify-swift/blob/6d192e4f3a6ae3855abb479aba090a36e083ce83/Package.swift#L38C1-L39C1) is set to from: "3.1.0" and [PodSpec](https://github.com/aws-amplify/amplify-swift/blob/v1/AmplifyPlugins.podspec#L39) to ss.dependency 'AppSyncRealTimeClient', "~> 3.1"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
