### PR TITLE
fix: update AppSyncRTC dependency version

### DIFF
--- a/AWSAppSync.podspec
+++ b/AWSAppSync.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'AWSCore', '~> 2.35.0'
   s.dependency 'SQLite.swift', '~> 0.12.2'
-  s.dependency 'AppSyncRealTimeClient', '~> 3'
+  s.dependency 'AppSyncRealTimeClient', '~> 3.1.0'
 
   s.source_files = 'AWSAppSyncClient/AWSAppSync.h', 'AWSAppSyncClient/*.swift', 'AWSAppSyncClient/Internal/**/*.{h,m,swift}', 'AWSAppSyncClient/Apollo/Sources/Apollo/*.swift'
   s.public_header_files = ['AWSAppSyncClient/AWSAppSync.h', 'AWSAppSyncClient/AWSAppSync-Swift.h', 'AWSAppSyncClient/Internal/AppSyncLogHelper.h']

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
         "state": {
           "branch": null,
-          "revision": "3de274c68a3cb60c8aec18b5bc0a8c07860219cd",
-          "version": "3.0.0"
+          "revision": "a08684c5004e2049c29f57a5938beae9695a1ef7",
+          "version": "3.1.2"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/daltoniam/Starscream",
         "state": {
           "branch": null,
-          "revision": "ac6c0fc9da221873e01bd1a0d4818498a71eef33",
-          "version": "4.0.6"
+          "revision": "df8d82047f6654d8e4b655d1b1525c64e1059d21",
+          "version": "4.0.4"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -19,11 +19,11 @@ let package = Package(
         .package(
             name: "AppSyncRealTimeClient",
             url: "https://github.com/aws-amplify/aws-appsync-realtime-client-ios.git",
-            from: "3.0.0"
+            .upToNextMinor(from: "3.1.0")
         ),
         .package(
             url: "https://github.com/stephencelis/SQLite.swift.git",
-            from: "0.12.0"
+            .upToNextMinor(from: "0.12.0")
         )
     ],
     targets: [

--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ AWS_SDK_VERSION = "2.35.0"
 target "AWSAppSync" do
   pod "AWSCore", "~> #{AWS_SDK_VERSION}"
   pod "SQLite.swift", "~> 0.12.2"
-  pod "AppSyncRealTimeClient", "~> 3.0.0"
+  pod "AppSyncRealTimeClient", "~> 3.1.0"
 
   pod "SwiftLint"
 end
@@ -18,7 +18,7 @@ target "AWSAppSyncTestCommon" do
   # We directly access a database connection to verify certain initialization
   # setups
   pod "SQLite.swift", "~> 0.12.2"
-  pod "AppSyncRealTimeClient", "~> 3.0.0"
+  pod "AppSyncRealTimeClient", "~> 3.1.0"
 end
 
 target "AWSAppSyncTestApp" do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - AppSyncRealTimeClient (3.0.0):
-    - Starscream (~> 4.0.4)
+  - AppSyncRealTimeClient (3.1.2):
+    - Starscream (= 4.0.4)
   - AWSAuthCore (2.35.0):
     - AWSCore (= 2.35.0)
   - AWSCognitoIdentityProvider (2.35.0):
@@ -23,7 +23,7 @@ PODS:
   - SwiftLint (0.51.0)
 
 DEPENDENCIES:
-  - AppSyncRealTimeClient (~> 3.0.0)
+  - AppSyncRealTimeClient (~> 3.1.0)
   - AWSCore (~> 2.35.0)
   - AWSMobileClient (~> 2.35.0)
   - AWSS3 (~> 2.35.0)
@@ -44,7 +44,7 @@ SPEC REPOS:
     - SwiftLint
 
 SPEC CHECKSUMS:
-  AppSyncRealTimeClient: ec19a24f635611b193eb98a2da573abcf98b793b
+  AppSyncRealTimeClient: 36ff2f65f330bce7f1d0d2157a4ae5d255483dac
   AWSAuthCore: aa5090b8d86389f958c5b916f14dc218b0c20f8e
   AWSCognitoIdentityProvider: b4c4d7d78782d62636cb3edfed71472dffe5e6d6
   AWSCognitoIdentityProviderASF: 295cac5c59c71c1494a3bac437f4c6284b9a73d3
@@ -55,6 +55,6 @@ SPEC CHECKSUMS:
   Starscream: 5178aed56b316f13fa3bc55694e583d35dd414d9
   SwiftLint: 1b7561918a19e23bfed960e40759086e70f4dba5
 
-PODFILE CHECKSUM: 9feff1c8c761826da553ff061352e1d8b723378e
+PODFILE CHECKSUM: 4274fcb3deaee92953e6a57b22eea5f821c5d4c1
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- update AppSyncRealTimeClient dependency version before bumping to 3.2.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
