### PR TITLE
Fixes #600. Be explicit about which Expression is being imported

### DIFF
--- a/AWSAppSyncClient/Internal/AWSAppSyncSubscriptionMetadataCache.swift
+++ b/AWSAppSyncClient/Internal/AWSAppSyncSubscriptionMetadataCache.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import SQLite
+import struct SQLite.Expression
 
 final class AWSSubscriptionMetaDataCache {
     

--- a/AWSAppSyncClient/Internal/AWSMutationCache.swift
+++ b/AWSAppSyncClient/Internal/AWSMutationCache.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import SQLite
+import struct SQLite.Expression
 
 /// Although this class is currently public, it is not intended to be used by clients, and will be marked "internal" in
 /// a future release of AppSync.

--- a/AWSAppSyncClient/Internal/AWSSQLiteNormalizedCache.swift
+++ b/AWSAppSyncClient/Internal/AWSSQLiteNormalizedCache.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import SQLite
+import struct SQLite.Expression
 
 /*
  The "timeout" method is used to control how long the SQLite library will wait for locks to clear before giving up on a database transaction. The default timeout is 0 millisecond. (In other words, the default behavior is not to wait at all.)


### PR DESCRIPTION
*Issue #, if available:* [600](https://github.com/awslabs/aws-mobile-appsync-sdk-ios/issues/600)

*Description of changes:*

iOS 18 adds a new Expression type to Foundation which conflicts with SQLite. Explicitly import SQLite's.

