### PR TITLE
chore: Temporary using xcodeproj's commit that bumps rexml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@
 source "https://rubygems.org"
 gem 'cocoapods', '1.11.3'
 gem 'cocoapods-downloader', '1.6.3'
+gem "xcodeproj", git: "https://github.com/CocoaPods/Xcodeproj.git", :branch => "master", ref: "fe55cf5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,23 @@
+GIT
+  remote: https://github.com/CocoaPods/Xcodeproj.git
+  revision: fe55cf57badef2ca27fb9d4f801d9b834de1f871
+  ref: fe55cf5
+  branch: master
+  specs:
+    xcodeproj (1.24.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.3.0)
+      rexml (>= 3.3.2, < 4.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.5)
+    CFPropertyList (3.0.7)
+      base64
+      nkf
       rexml
     activesupport (6.1.7.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -15,6 +31,7 @@ GEM
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
+    base64 (0.2.0)
     claide (1.1.0)
     cocoapods (1.11.3)
       addressable (~> 2.8)
@@ -71,22 +88,16 @@ GEM
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
+    nkf (0.2.0)
     public_suffix (4.0.6)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     ruby-macho (2.5.1)
     strscan (3.1.0)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.21.0)
-      CFPropertyList (>= 2.3.3, < 4.0)
-      atomos (~> 0.1.3)
-      claide (>= 1.0.2, < 2.0)
-      colored2 (~> 3.1)
-      nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -95,6 +106,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (= 1.11.3)
   cocoapods-downloader (= 1.6.3)
+  xcodeproj!
 
 BUNDLED WITH
    2.3.7


### PR DESCRIPTION
**Description of changes:**

This PR uses Xcodeproj's latest [main commit](https://github.com/CocoaPods/Xcodeproj/commit/fe55cf57badef2ca27fb9d4f801d9b834de1f871) so that its dependency to `rexml` can be upgraded.

We're doing this temporary until they release a proper new version, at which point we will point to that one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
