### PR TITLE
chore: update xcodeproj gem to 1.25.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,3 @@
 source "https://rubygems.org"
 gem 'cocoapods', '1.11.3'
 gem 'cocoapods-downloader', '1.6.3'
-gem "xcodeproj", git: "https://github.com/CocoaPods/Xcodeproj.git", :branch => "master", ref: "fe55cf5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,3 @@
-GIT
-  remote: https://github.com/CocoaPods/Xcodeproj.git
-  revision: fe55cf57badef2ca27fb9d4f801d9b834de1f871
-  ref: fe55cf5
-  branch: master
-  specs:
-    xcodeproj (1.24.0)
-      CFPropertyList (>= 2.3.3, < 4.0)
-      atomos (~> 0.1.3)
-      claide (>= 1.0.2, < 2.0)
-      colored2 (~> 3.1)
-      nanaimo (~> 0.3.0)
-      rexml (>= 3.3.2, < 4.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -90,7 +76,7 @@ GEM
     netrc (0.11.0)
     nkf (0.2.0)
     public_suffix (4.0.6)
-    rexml (3.3.3)
+    rexml (3.3.4)
       strscan
     ruby-macho (2.5.1)
     strscan (3.1.0)
@@ -98,6 +84,13 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    xcodeproj (1.25.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.3.0)
+      rexml (>= 3.3.2, < 4.0)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -106,7 +99,6 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (= 1.11.3)
   cocoapods-downloader (= 1.6.3)
-  xcodeproj!
 
 BUNDLED WITH
-   2.3.7
+   2.5.14


### PR DESCRIPTION
*Issue #, if available:*
Dependabot alert for rexml vulnerability

*Description of changes:*
Revert changes in https://github.com/awslabs/aws-mobile-appsync-sdk-ios/pull/602

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
